### PR TITLE
LPS-96466 Fix sidenav on old Chrome and old Firefox

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
@@ -725,7 +725,7 @@ SideNavigation.prototype = {
 			loading.innerHTML = instance.options.loadingIndicatorTPL;
 
 			sidebar.appendChild(loading);
-			instance._fetchPromise = fetch(url);
+			instance._fetchPromise = Liferay.Util.fetch(url);
 
 			instance._fetchPromise
 				.then(response => {


### PR DESCRIPTION
This worked fine on latest Chrome, Firefox, and on IE 11, but it doesn't work on old Firefox (eg. 60) or old Chrome (eg. 65). The latter in particular is a critical problem because it's the one we use in CI.

Inspection revealed a discrepancy in the behavior of `fetch()` on those older browsers (they weren't sending cookies, causing the network requests to fail), which we can fix by switching to our standard fetch utility (that we just added in 91d3054b), which includes cookies with all requests by default.

I've created an LPS ([LPS-96485](https://issues.liferay.com/browse/LPS-96485)) for adding a lint that enforces the use of `Liferay.Util.fetch` rather than bare `fetch` everywhere.