### PR TITLE
 LPS-96923 Make management toolbar info buttons work after nav

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
@@ -212,7 +212,11 @@ function subscribe(element, eventName, handler) {
 		}
 
 		const emitter = emitters[selector];
-		const subscription = emitter.on(eventName, handler);
+		const subscription = emitter.on(eventName, event => {
+			if (!event.defaultPrevented) {
+				handler(event);
+			}
+		});
 
 		return {
 			dispose() {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.es.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/management_toolbar/ManagementToolbar.es.js
@@ -89,6 +89,14 @@ class ManagementToolbar extends ClayComponent {
 	disposed(...args) {
 		super.disposed(...args);
 
+		if (this.infoPanelId) {
+			const sidenavToggle = this.refs.managementToolbar.refs.infoButton;
+
+			if (sidenavToggle) {
+				Liferay.SideNavigation.destroy(sidenavToggle);
+			}
+		}
+
 		if (this._eventHandler) {
 			this._eventHandler.forEach(eventHandler => {
 				eventHandler.detach();


### PR DESCRIPTION
The "Info" button in the management toolbar wasn't working after navigation, because we were winding up with duplicate event listeners which ended up canceling each other out (ie. you would click on the button and the side nav would open but then close again instantly).

Two parts to this fix:

1. Make the SideNavigation resilient to duplicate event listeners being registered. This alone is enough to fix the bug.
2. Make ManagementToolbar clean up properly when it is detached. This would also be enough to fix the bug.

We apply both fixes because one addresses the root cause, and the other makes us robust in the face of similar problems in the future.