### PR TITLE
LPS-97472 | Remove lint suppressions from hello-soy | Do not forward, this PR breaks the portlet

### DIFF
--- a/modules/apps/hello-soy/hello-soy-navigation-web/src/main/resources/META-INF/resources/Navigation.es.js
+++ b/modules/apps/hello-soy/hello-soy-navigation-web/src/main/resources/META-INF/resources/Navigation.es.js
@@ -12,12 +12,11 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import Component from 'metal-component';
-import Footer from 'hello-soy-web/Footer.soy';
-import Header from 'hello-soy-web/Header.soy';
 import Soy from 'metal-soy';
+
+import 'hello-soy-web/Footer.soy';
+import 'hello-soy-web/Header.soy';
 import templates from './Navigation.soy';
 
 class Navigation extends Component {}

--- a/modules/apps/hello-soy/hello-soy-web/src/main/resources/META-INF/resources/View.es.js
+++ b/modules/apps/hello-soy/hello-soy-web/src/main/resources/META-INF/resources/View.es.js
@@ -12,12 +12,11 @@
  * details.
  */
 
-/* eslint no-unused-vars: "warn" */
-
 import Component from 'metal-component';
-import Footer from './Footer.soy';
-import Header from './Header.soy';
 import Soy from 'metal-soy';
+
+import './Footer.soy';
+import './Header.soy';
 import templates from './View.soy';
 
 class View extends Component {}


### PR DESCRIPTION
Hi @wincent ,

Please do not forward, these changes completely break the portlet. I cannot figure out why:
- In no other portlet do we reference soy files directly, maybe this way of importing requires var assignment?
- It may be related to the fact that the portlet is broken even before changes, that soy may be wired in an obsolete way. See https://issues.liferay.com/browse/LPS-97761

@brunobasto could you maybe help with this one?

Thank you!