### PR TITLE
LPS-103570 Restructure JSP to avoid unwanted Prettier changes

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/modified.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/facets/view/modified.jsp
@@ -297,12 +297,14 @@ int index = 0;
 				LString.padNumber(dayTo, 2) +
 				'235959]';
 
-			Liferay.Util.postForm(form, {
-				data: {
-					<%= HtmlUtil.escapeJS(facet.getFieldId()) %>: range,
-					<%= HtmlUtil.escapeJS(facet.getFieldId()) %>selection: selection
-				}
-			});
+			var data = {};
+
+			data['<%= HtmlUtil.escapeJS(facet.getFieldId()) %>'] = range;
+			data[
+				'<%= HtmlUtil.escapeJS(facet.getFieldId()) %>selection'
+			] = selection;
+
+			Liferay.Util.postForm(form, {data: data});
 		}
 	}
 </aui:script>

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/configuration.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/type/facet/configuration.jsp
@@ -85,13 +85,13 @@ TypeFacetPortletPreferences typeFacetPortletPreferences = new com.liferay.portal
 		form.addEventListener('submit', function(event) {
 			event.preventDefault();
 
-			Liferay.Util.postForm(form, {
-				data: {
-					<%= PortletPreferencesJspUtil.getInputName(TypeFacetPortletPreferences.PREFERENCE_KEY_ASSET_TYPES) %>: Liferay.Util.listSelect(
-						currentAssetTypes
-					)
-				}
-			});
+			var data = {};
+
+			data[
+				'<%= PortletPreferencesJspUtil.getInputName(TypeFacetPortletPreferences.PREFERENCE_KEY_ASSET_TYPES) %>'
+			] = Liferay.Util.listSelect(currentAssetTypes);
+
+			Liferay.Util.postForm(form, {data: data});
 		});
 	}
 </script>

--- a/modules/apps/site-navigation/site-navigation-breadcrumb-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/site-navigation/site-navigation-breadcrumb-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -77,15 +77,26 @@
 </liferay-frontend:edit-form>
 
 <aui:script sandbox="<%= true %>">
-	var data = {
-		_<%= HtmlUtil.escapeJS(siteNavigationBreadcrumbDisplayContext.getPortletResource()) %>_displayStyle:
-			'<%= siteNavigationBreadcrumbDisplayContext.getDisplayStyle() %>',
-		_<%= HtmlUtil.escapeJS(siteNavigationBreadcrumbDisplayContext.getPortletResource()) %>_showCurrentGroup: <%= siteNavigationBreadcrumbDisplayContext.isShowCurrentGroup() %>,
-		_<%= HtmlUtil.escapeJS(siteNavigationBreadcrumbDisplayContext.getPortletResource()) %>_showGuestGroup: <%= siteNavigationBreadcrumbDisplayContext.isShowGuestGroup() %>,
-		_<%= HtmlUtil.escapeJS(siteNavigationBreadcrumbDisplayContext.getPortletResource()) %>_showLayout: <%= siteNavigationBreadcrumbDisplayContext.isShowLayout() %>,
-		_<%= HtmlUtil.escapeJS(siteNavigationBreadcrumbDisplayContext.getPortletResource()) %>_showParentGroups: <%= siteNavigationBreadcrumbDisplayContext.isShowParentGroups() %>,
-		_<%= HtmlUtil.escapeJS(siteNavigationBreadcrumbDisplayContext.getPortletResource()) %>_showPortletBreadcrumb: <%= siteNavigationBreadcrumbDisplayContext.isShowPortletBreadcrumb() %>
-	};
+	var data = {};
+
+	data[
+		'_<%= HtmlUtil.escapeJS(siteNavigationBreadcrumbDisplayContext.getPortletResource()) %>_displayStyle'
+	] = '<%= siteNavigationBreadcrumbDisplayContext.getDisplayStyle() %>';
+	data[
+		'_<%= HtmlUtil.escapeJS(siteNavigationBreadcrumbDisplayContext.getPortletResource()) %>_showCurrentGroup'
+	] = <%= siteNavigationBreadcrumbDisplayContext.isShowCurrentGroup() %>;
+	data[
+		'_<%= HtmlUtil.escapeJS(siteNavigationBreadcrumbDisplayContext.getPortletResource()) %>_showGuestGroup'
+	] = <%= siteNavigationBreadcrumbDisplayContext.isShowGuestGroup() %>;
+	data[
+		'_<%= HtmlUtil.escapeJS(siteNavigationBreadcrumbDisplayContext.getPortletResource()) %>_showLayout'
+	] = <%= siteNavigationBreadcrumbDisplayContext.isShowLayout() %>;
+	data[
+		'_<%= HtmlUtil.escapeJS(siteNavigationBreadcrumbDisplayContext.getPortletResource()) %>_showParentGroups'
+	] = <%= siteNavigationBreadcrumbDisplayContext.isShowParentGroups() %>;
+	data[
+		'_<%= HtmlUtil.escapeJS(siteNavigationBreadcrumbDisplayContext.getPortletResource()) %>_showPortletBreadcrumb'
+	] = <%= siteNavigationBreadcrumbDisplayContext.isShowPortletBreadcrumb() %>;
 
 	var selectDisplayStyle = document.getElementById(
 		'<portlet:namespace />displayStyle'

--- a/portal-web/docroot/html/portal/render_portlet.jsp
+++ b/portal-web/docroot/html/portal/render_portlet.jsp
@@ -1027,22 +1027,21 @@ if (themeDisplay.isStatePopUp()) {
 			if (window.parent) {
 				var data = {
 					portletAjaxable: <%= !(((portletResourcePortlet != null) && !portletResourcePortlet.isAjaxable()) || SessionMessages.contains(liferayRenderRequest, portletId + SessionMessages.KEY_SUFFIX_PORTLET_NOT_AJAXABLE)) %>
-
-					<c:if test="<%= (refreshPortletData != null) && !refreshPortletData.isEmpty() %>">
-
-						<%
-						for (Map.Entry<String, String> entry : refreshPortletData.entrySet()) {
-						%>
-
-							, '<%= entry.getKey() %>': <%= entry.getValue() %>
-
-						<%
-						}
-						%>
-
-					</c:if>
-
 				};
+
+				<c:if test="<%= (refreshPortletData != null) && !refreshPortletData.isEmpty() %>">
+
+					<%
+					for (Map.Entry<String, String> entry : refreshPortletData.entrySet()) {
+					%>
+
+						data['<%= entry.getKey() %>'] = <%= entry.getValue() %>;
+
+					<%
+					}
+					%>
+
+				</c:if>
 
 				Liferay.Util.getOpener().Liferay.Portlet.refresh('#p_p_id_<%= HtmlUtil.escapeJS(refreshPortletId) %>_', data);
 			}
@@ -1116,22 +1115,21 @@ if (themeDisplay.isStatePopUp()) {
 						if (window.parent) {
 							var data = {
 								portletAjaxable: <%= !(((portletResourcePortlet != null) && !portletResourcePortlet.isAjaxable()) || SessionMessages.contains(liferayRenderRequest, portletId + SessionMessages.KEY_SUFFIX_PORTLET_NOT_AJAXABLE)) %>
-
-								<c:if test="<%= (refreshPortletData != null) && !refreshPortletData.isEmpty() %>">
-
-									<%
-									for (Map.Entry<String, String> entry : refreshPortletData.entrySet()) {
-									%>
-
-										, '<%= entry.getKey() %>': <%= entry.getValue() %>
-
-									<%
-									}
-									%>
-
-								</c:if>
-
 							};
+
+							<c:if test="<%= (refreshPortletData != null) && !refreshPortletData.isEmpty() %>">
+
+								<%
+								for (Map.Entry<String, String> entry : refreshPortletData.entrySet()) {
+								%>
+
+									data['<%= entry.getKey() %>'] = <%= entry.getValue() %>;
+
+								<%
+								}
+								%>
+
+							</c:if>
 
 							refreshWindow.Liferay.Portlet.refresh('#p_p_id_<%= closeRefreshPortletId %>_', data);
 						}

--- a/portal-web/docroot/html/taglib/aui/fieldset/lexicon/end.jsp
+++ b/portal-web/docroot/html/taglib/aui/fieldset/lexicon/end.jsp
@@ -28,11 +28,11 @@
 			'hide.bs.collapse show.bs.collapse',
 			function(event) {
 				if (event.target.id === '<%= id %>Content') {
-					storeTask(
-						{
-							'<%= id %>': (event.type === 'hide')
-						}
-					);
+					var task = {};
+
+					task['<%= id %>'] = event.type === 'hide';
+
+					storeTask(task);
 				}
 			}
 		);

--- a/portal-web/docroot/html/taglib/ui/panel/lexicon/end.jsp
+++ b/portal-web/docroot/html/taglib/ui/panel/lexicon/end.jsp
@@ -28,11 +28,11 @@
 			'hide.bs.collapse show.bs.collapse',
 			function(event) {
 				if (event.target.id === '<%= id %>Content') {
-					storeTask(
-						{
-							'<%= id %>': (event.type === 'hide')
-						}
-					);
+					var task = {};
+
+					task['<%= id %>'] = event.type === 'hide';
+
+					storeTask(task);
 				}
 			}
 		);


### PR DESCRIPTION
Victor brought this to my attention in [\#80065](https://github.com/brianchandotcom/liferay-portal/pull/80065).

The nature of the problem is explained in:

https://github.com/liferay/liferay-npm-tools/issues/300

But the TL;DR is that Prettier may improperly remove quotes around object property names that contain JSP expressions, and at the time we prepare the text to pass to Prettier, we don't have have an AST yet and therefore don't have enough information to be totally robust.

Just in case similar problems exist elsewhere I did a full audit to identify potential problems. There are 43 places in liferay-portal (and there were 0 in liferay-portal-ee) where Prettier removed these quotes, and of those 3 were definitely problematic, and 11 can't be statically analyzed (so we should restructure them just to be safe).

So, this commit fixes the 2 of the definite problems (the other one is handled by Victor's PR), and also makes the 11 others safe, just in case, to rule out possible regressions.

Moving forward, we probably don't have to worry about new call sites because any problems caused by the lack of quotes should be immediately obvious.