### PR TITLE
LPS-103699 Not all ids are valid Js identifiers

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/end.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/end.jsp
@@ -29,7 +29,7 @@
 		) {
 			if (event.target.id === '<%= id %>Content') {
 				storeTask({
-					<%= id %>: event.type === 'hide'
+					'<%= id %>': event.type === 'hide'
 				});
 			}
 		});


### PR DESCRIPTION
Hey @wincent 

This reverts part of LPS-98032. It is not safe to assume all IDs are safe Js identifiers (e.g. the fieldset tag will use the label as an ID, and labels use '-' as a separator usually). Not sure if there are more places where a similar change was made, so I'm sending this to you so that you can double check everything is ok.

Thanks!