### PR TITLE
LPS-105703 - Staging - Remove jQuery

### DIFF
--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revisions.jsp
@@ -176,21 +176,23 @@ function <portlet:namespace />selectRevision(
 	layoutRevisionId,
 	layoutSetBranchId
 ) {
-	AUI.$.ajax(themeDisplay.getPathMain() + '/portal/update_layout', {
-		data: {
-			cmd: 'select_layout_revision',
-			doAsUserId: themeDisplay.getDoAsUserIdEncoded(),
-			layoutRevisionId: layoutRevisionId,
-			layoutSetBranchId: layoutSetBranchId,
-			p_auth: Liferay.authToken,
-			p_l_id: themeDisplay.getPlid(),
-			p_v_l_s_g_id: themeDisplay.getSiteGroupId()
-		},
-		success: function(event, id, obj) {
-			var parentWindow = Liferay.Util.getOpener();
+	var updateLayoutData = {
+		cmd: 'select_layout_revision',
+		doAsUserId: themeDisplay.getDoAsUserIdEncoded(),
+		layoutRevisionId: layoutRevisionId,
+		layoutSetBranchId: layoutSetBranchId,
+		p_auth: Liferay.authToken,
+		p_l_id: themeDisplay.getPlid(),
+		p_v_l_s_g_id: themeDisplay.getSiteGroupId()
+	};
 
-			parentWindow.location = parentWindow.location.href.split('?')[0];
-		}
+	Liferay.Util.fetch(themeDisplay.getPathMain() + '/portal/update_layout', {
+		body: Liferay.Util.objectToFormData(updateLayoutData),
+		method: 'POST'
+	}).then(function() {
+		var parentWindow = Liferay.Util.getOpener();
+
+		parentWindow.location = parentWindow.location.href.split('?')[0];
 	});
 }
 

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
@@ -15,8 +15,6 @@
 AUI.add(
 	'liferay-staging-processes-export-import',
 	A => {
-		var $ = AUI.$;
-
 		var Lang = A.Lang;
 
 		var ADate = A.Date;
@@ -100,46 +98,44 @@ AUI.add(
 						);
 					}
 
-					$('[id^=' + instance.ns('PORTLET_DATA') + ']').each(
-						function() {
-							var checkBox = $(this);
-
-							checkBox.on(STR_CLICK, () => {
-								if (checkBox.is(':checked')) {
-									var id = checkBox.prop('id');
-
-									var controlCheckboxes = $(
-										'[data-root-control-id=' + id + ']'
-									);
-
-									if (controlCheckboxes.length == 0) {
-										return;
-									}
-
-									controlCheckboxes.each(function() {
-										var controlCheckbox = $(this);
-
-										if (!controlCheckbox.is(':checked')) {
-											controlCheckbox.trigger(STR_CLICK);
-										}
-									});
-
-									var portletId = id.replace(
-										instance.ns('PORTLET_DATA') + '_',
-										''
-									);
-
-									instance._setContentLabels(portletId);
-
-									var contentNode = instance.byId(
-										'content_' + portletId
-									);
-
-									instance._storeNodeInputStates(contentNode);
-								}
-							});
-						}
+					const checkboxes = document.querySelectorAll(
+						`[id^=${instance.ns('PORTLET_DATA')}]`
 					);
+
+					if (checkboxes.length > 0) {
+						document.body.addEventListener('click', event => {
+							const {id} = event.target;
+
+							if (id.includes(instance.ns('PORTLET_DATA'))) {
+								const controlCheckboxes = document.querySelectorAll(
+									`[data-root-control-id=${id}]`
+								);
+
+								if (controlCheckboxes.length > 0) {
+									controlCheckboxes.forEach(
+										controlCheckbox => {
+											if (!controlCheckbox.checked) {
+												controlCheckbox.click();
+											}
+										}
+									);
+								}
+
+								const portletId = id.replace(
+									`${instance.ns('PORTLET_DATA')}_`,
+									''
+								);
+
+								instance._setContentLabels(portletId);
+
+								const contentNode = instance.byId(
+									'content_' + portletId
+								);
+
+								instance._storeNodeInputStates(contentNode);
+							}
+						});
+					}
 
 					var changeToPublicLayoutsButton = instance.byId(
 						'changeToPublicLayoutsButton'


### PR DESCRIPTION
Hey Greg, can you give this a look please.

- Here's where to find the `staging-bar-web` thingy:
![image](https://user-images.githubusercontent.com/24564752/70803314-10b77a00-1db4-11ea-9655-9d3bbbc17b28.png)
- Before you click on `history` add a portlet onto the home page, this will be needed to test
- After you've added a random portlet on a page and clicked `history` you'll see 2 different versions, click on the one that you can, the screen looks like this:
![image](https://user-images.githubusercontent.com/24564752/70803747-12ce0880-1db5-11ea-8be9-e0bb8794e8dd.png)

![image](https://user-images.githubusercontent.com/24564752/70803314-10b77a00-1db4-11ea-9655-9d3bbbc17b28.png)

- Here's where to find the `staging-processes-web` thingy:
Sidebar > Staging > Processes tab > `+`
![image](https://user-images.githubusercontent.com/24564752/70803182-c0d8b300-1db3-11ea-8a35-1828723c14aa.png)
