### PR TITLE
LPS-108648 Remove AUI from Liferay.Portal.Tabs

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -34,6 +34,7 @@ import {
 	showLayoutPane,
 	toggleLayoutDetails
 } from './layout_exporter.es';
+import {showTab} from './portal/tabs.es';
 import portlet from './portlet/portlet.es';
 import SideNavigation from './side_navigation.es';
 import getCountries from './util/address/get_countries.es';
@@ -79,6 +80,12 @@ Liferay.LayoutExporter = {
 	proposeLayout,
 	publishToLive,
 	selected: showLayoutPane
+};
+
+Liferay.Portal = Liferay.Portal || {};
+
+Liferay.Portal.Tabs = {
+	show: showTab
 };
 
 Liferay.SideNavigation = SideNavigation;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portal.js
@@ -13,93 +13,11 @@
  */
 
 (function(A, Liferay) {
-	var Tabs = Liferay.namespace('Portal.Tabs');
 	var ToolTip = Liferay.namespace('Portal.ToolTip');
 
 	var BODY_CONTENT = 'bodyContent';
 
 	var TRIGGER = 'trigger';
-
-	Liferay.Portal.Tabs._show = function(event) {
-		var names = event.names;
-		var namespace = event.namespace;
-
-		var selectedIndex = event.selectedIndex;
-
-		var tabItem = event.tabItem;
-		var tabLink = tabItem.one('a');
-		var tabSection = event.tabSection;
-
-		if (tabItem) {
-			var previousTabItem = tabItem.siblings().one('.active');
-
-			if (previousTabItem) {
-				previousTabItem.removeClass('active');
-			}
-
-			tabLink.addClass('active');
-		}
-
-		if (tabSection) {
-			tabSection.show();
-		}
-
-		var tabTitle = A.one('#' + event.namespace + 'dropdownTitle');
-
-		if (tabTitle) {
-			tabTitle.html(tabLink.text());
-		}
-
-		names.splice(selectedIndex, 1);
-
-		var el;
-
-		for (var i = 0; i < names.length; i++) {
-			el = A.one(
-				'#' +
-					namespace +
-					Liferay.Util.toCharCode(names[i]) +
-					'TabsSection'
-			);
-
-			if (el) {
-				el.hide();
-			}
-		}
-	};
-
-	Liferay.provide(
-		Tabs,
-		'show',
-		function(namespace, names, id, callback) {
-			var namespacedId = namespace + Liferay.Util.toCharCode(id);
-
-			var tab = A.one('#' + namespacedId + 'TabsId');
-			var tabSection = A.one('#' + namespacedId + 'TabsSection');
-
-			if (tab && tabSection) {
-				var details = {
-					id,
-					names,
-					namespace,
-					selectedIndex: names.indexOf(id),
-					tabItem: tab,
-					tabSection
-				};
-
-				if (callback && A.Lang.isFunction(callback)) {
-					callback.call(this, namespace, names, id, details);
-				}
-
-				Liferay.fire('showTab', details);
-			}
-		},
-		['aui-base']
-	);
-
-	Liferay.publish('showTab', {
-		defaultFn: Liferay.Portal.Tabs._show
-	});
 
 	ToolTip._getText = function(id) {
 		var node = A.one('#' + id);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portal/tabs.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portal/tabs.es.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import toCharCode from '../util/to_char_code.es';
+
+const EVENT_SHOW_TAB = 'showTab';
+
+/**
+ * Prepares and fires the an event that will show a tab
+ * @param {String} namespace The portlet's namespace
+ * @param {Array} names Names of all tabs
+ * @param {String} id Tab id.
+ * @param {Function} callback The callback function.
+ */
+export function showTab(namespace, names, id, callback) {
+	const namespacedId = namespace + toCharCode(id);
+
+	const selectedTab = document.getElementById(namespacedId + 'TabsId');
+	const selectedTabSection = document.getElementById(
+		namespacedId + 'TabsSection'
+	);
+
+	if (selectedTab && selectedTabSection) {
+		const details = {
+			id,
+			names,
+			namespace,
+			selectedTab,
+			selectedTabSection
+		};
+
+		if (callback && typeof callback === 'function') {
+			callback.call(this, namespace, names, id, details);
+		}
+
+		try {
+			Liferay.on(EVENT_SHOW_TAB, applyTabSelectionDOMChanges);
+
+			Liferay.fire(EVENT_SHOW_TAB, details);
+		}
+		finally {
+			Liferay.detach(EVENT_SHOW_TAB, applyTabSelectionDOMChanges);
+		}
+	}
+}
+
+/**
+ * Applies DOM changes that represent tab selection
+ * @param {String} namespace The portlet's namespace
+ * @param {Array} names Names of all tabs
+ * @param {String} id Tab id.
+ * @param {HTMLElement} selectedTab Selected tab element
+ * @param {HTMLElement} selectedTabSection Selected tab section element
+ */
+export function applyTabSelectionDOMChanges({
+	id,
+	names,
+	namespace,
+	selectedTab,
+	selectedTabSection
+}) {
+	const selectedTabLink = selectedTab.querySelector('a');
+
+	if (selectedTab && selectedTabLink) {
+		const activeTab = selectedTab.parentElement.querySelector('.active');
+
+		if (activeTab) {
+			activeTab.classList.remove('active');
+		}
+
+		selectedTabLink.classList.add('active');
+	}
+
+	if (selectedTabSection) {
+		selectedTabSection.classList.remove('hide');
+	}
+
+	const tabTitle = document.getElementById(namespace + 'dropdownTitle');
+
+	if (tabTitle && selectedTabLink) {
+		tabTitle.innerHTML = selectedTabLink.textContent;
+	}
+
+	names.splice(names.indexOf(id), 1);
+
+	let tabSection;
+
+	for (var i = 0; i < names.length; i++) {
+		tabSection = document.getElementById(
+			namespace + toCharCode(names[i]) + 'TabsSection'
+		);
+
+		if (tabSection) {
+			tabSection.classList.add('hide');
+		}
+	}
+}

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/portal/tabs.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/portal/tabs.es.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+'use strict';
+
+import {
+	applyTabSelectionDOMChanges,
+	showTab
+} from '../../../src/main/resources/META-INF/resources/liferay/portal/tabs.es';
+import toCharCode from '../../../src/main/resources/META-INF/resources/liferay/util/to_char_code.es';
+
+describe('Liferay.Portal.Tabs.show', () => {
+	it('fires the showTab custom event and executes callback', () => {
+		const id = 'tab2';
+		const namespace = 'abcd';
+		const names = ['tab1', 'tab2'];
+		const callback = jest.fn();
+
+		Liferay.fire = jest.fn((type, details) => {
+			expect(type).toBe('showTab');
+			expect(details.id).toBe(id);
+			expect(details.names).toBe(names);
+			expect(details.namespace).toBe(namespace);
+			expect(details.selectedTab.nodeType).toBe(1);
+			expect(details.selectedTabSection.nodeType).toBe(1);
+		});
+
+		const namespacedId = namespace + toCharCode(id);
+
+		document.body.innerHTML = `
+			<div id="${namespacedId}TabsId"></div>
+			<div id="${namespacedId}TabsSection"></div>
+		`;
+
+		showTab(namespace, names, id, callback);
+
+		expect(callback).toHaveBeenCalled();
+	});
+});
+
+describe('Liferay.Portal.Tabs.applyTabSelectionDOMChanges', () => {
+	it('applies DOM changes when setting an active tab', () => {
+		const id = 'tab2';
+		const namespace = 'abcd';
+		const names = ['tab1', 'tab2', 'tab3'];
+
+		const ids = [
+			namespace + toCharCode(names[0]),
+			namespace + toCharCode(names[1]),
+			namespace + toCharCode(names[2])
+		];
+
+		document.body.innerHTML = `
+			<div>
+				<div id="${ids[0]}TabsId">
+					<a class="active">First</a>
+				</div>
+				<div id="${ids[1]}TabsId">
+					<a><b>Second</b></a>
+				</div>
+				<div id="${ids[2]}TabsId">
+					<a>Third</a>
+				</div>
+			<div>
+			<div>
+				<div id="${ids[0]}TabsSection"></div>
+				<div id="${ids[1]}TabsSection" class="hide"></div>
+				<div id="${ids[2]}TabsSection" class="hide"></div>
+			<div>
+			<div id="${namespace}dropdownTitle" class="hide"></div>
+		`;
+
+		applyTabSelectionDOMChanges({
+			id,
+			names,
+			namespace,
+			selectedTab: document.getElementById(`${ids[1]}TabsId`),
+			selectedTabSection: document.getElementById(`${ids[1]}TabsSection`)
+		});
+
+		const link1 = document.querySelector(`#${ids[0]}TabsId a`);
+		const link2 = document.querySelector(`#${ids[1]}TabsId a`);
+		const link3 = document.querySelector(`#${ids[2]}TabsId a`);
+
+		expect(link1.classList.contains('active')).toBe(false);
+		expect(link2.classList.contains('active')).toBe(true);
+		expect(link3.classList.contains('active')).toBe(false);
+
+		const section1 = document.getElementById(`${ids[0]}TabsSection`);
+		const section2 = document.getElementById(`${ids[1]}TabsSection`);
+		const section3 = document.getElementById(`${ids[2]}TabsSection`);
+
+		expect(section1.classList.contains('hide')).toBe(true);
+		expect(section2.classList.contains('hide')).toBe(false);
+		expect(section3.classList.contains('hide')).toBe(true);
+
+		const title = document.getElementById(`${namespace}dropdownTitle`);
+
+		expect(title.innerHTML).toBe('Second');
+	});
+});


### PR DESCRIPTION
Hey @wincent ,

This is a followup on https://github.com/wincent/liferay-portal/pull/144

Changes:
* Replaced `Liferay.publish` with the solution outlined in https://github.com/wincent/liferay-portal/pull/144#issuecomment-588899144. The only notable difference, I am using `on` instead of `after`, as there are places in the portal that subscribe with `after`, for example [here](https://github.com/liferay/liferay-portal/blob/ca27105132499eed21f10f8adcd565b5c0fc9907/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/form_builder.jspf#L286). 
* Added tests. For test purposes, I exposed `applyTabSelectionDOMChanges`, although it is strictly a private function. I guess if we ever discover a case where `showTab` is fired directly, we can offer replacing it with this function.

Please review the code.

Thank you!

/cc @jbalsas