### PR TITLE
LPS-109811 Unable to renavigate to widget configuration screens

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -92,10 +92,9 @@ Liferay.Portal = {
 	},
 };
 
-Liferay.Portlet = {
-	...Liferay.Portlet,
-	minimize: minimizePortlet,
-};
+Liferay.Portlet = Liferay.Portlet || {};
+
+Liferay.Portlet.minimize = minimizePortlet;
 
 Liferay.SideNavigation = SideNavigation;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
@@ -22,6 +22,8 @@
 	var TPL_NOT_AJAXABLE = '<div class="alert alert-info">{0}</div>';
 
 	var Portlet = {
+		...Liferay.Portlet,
+
 		_defCloseFn(event) {
 			event.portlet.remove(true);
 
@@ -743,8 +745,5 @@
 		});
 	};
 
-	Liferay.Portlet = {
-		...Liferay.Portlet,
-		...Portlet,
-	};
+	Liferay.Portlet = Portlet;
 })(AUI(), Liferay);


### PR DESCRIPTION
Hey @wincent ,

What the issue boils down to: merging objects by leveraging spread operator creates a new object, and `Liferay.provide` requires `Liferay.Portlet` object persistence. I must admit, I don't fully understand everything that we are doing in [provide implementation](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/dependency.js), but I see object mutations and functions binding, which I think is enough to conclude above.

In this PR, we are using spread operator before all the `Liferay.provide`s, it will affect new utils such as `minimize`, that will never have `provide`. I still like this safeguard, that it doesn't mater which file executes first. Currently, `global.es.js` executes first, but load orders are changing a lot nowadays. Eventually, we will rewrite away all `Liferay.provide`s so this won't be an issue.

Please review the code.

Thank you!

/cc @jbalsas @julien