### PR TITLE
LPS-111374 Fix failing ddm-form js-unit tests

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/package.json
@@ -19,6 +19,9 @@
 		"collectCoverageFrom": [
 			"src/main/resources/META-INF/resources/js/**/*.es.js"
 		],
+		"moduleNameMapper": {
+			"^./liferay/modal/Modal.es$": "<rootDir>/test/js/__mock__/Modal.es.js"
+		},
 		"modulePathIgnorePatterns": [
 			"/__mock__/"
 		],
@@ -37,8 +40,7 @@
 			"LayoutProvider/util",
 			"PageRenderer",
 			"RuleBuilder",
-			"RuleEditor",
-			"Sidebar"
+			"RuleEditor"
 		]
 	},
 	"main": "js/index.es.js",
@@ -47,7 +49,7 @@
 		"build": "liferay-npm-scripts build",
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix",
-		"test_DISABLED": "metalsoy -s \"test/**/*.soy\" -d \"test\" && liferay-npm-scripts test"
+		"test": "metalsoy -s \"test/**/*.soy\" -d \"test\" && liferay-npm-scripts test"
 	},
 	"version": "3.0.23"
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/__mock__/Modal.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-builder/test/js/__mock__/Modal.es.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+module.exports = {
+	// Mock this because we can't evaluate React JSX from a Metal-using module
+	// like dynamic-data-mapping-form-builder.
+	openModal: () => {},
+};

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/package.json
@@ -17,6 +17,9 @@
 		"object-hash": "^1.3.0"
 	},
 	"jest": {
+		"moduleNameMapper": {
+			"^./liferay/modal/Modal.es$": "<rootDir>/test/js/__mock__/Modal.es.js"
+		},
 		"modulePathIgnorePatterns": [
 			"/__mock__/"
 		],
@@ -27,7 +30,6 @@
 			"metal-jest-serializer"
 		],
 		"testPathIgnorePatterns": [
-			"AutoSave",
 			"ShareFormPopover"
 		]
 	},
@@ -38,7 +40,7 @@
 		"build": "liferay-npm-scripts build",
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix",
-		"test_DISABLED": "liferay-npm-scripts test"
+		"test": "liferay-npm-scripts test"
 	},
 	"version": "3.0.14"
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/__mock__/Modal.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/test/js/__mock__/Modal.es.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+module.exports = {
+	// Mock this because we can't evaluate React JSX from a Metal-using module
+	// like dynamic-data-mapping-form-web.
+	openModal: () => {},
+};


### PR DESCRIPTION
These tests were doubly disabled in:

- https://github.com/brianchandotcom/liferay-portal/pull/87152
- https://github.com/brianchandotcom/liferay-portal/pull/87153

Root cause:

These two modules, dynamic-data-mapping-form-builder and dynamic-data-mapping-form-web, are the only two places left in liferay-portal that we still use Metal's incremental-dom, which is incompatible with React.

In f7704c187c, we switched everything to assume React by default, but these two modules needed an explicit opt-out so that they could continue to use incremental-dom.

All of this was fine until f18e7fe22a, which added a React-powered modal to frontend-js-web. This caused these DDM tests to fail because they depend on frontend-js-web, and as soon as they hit React JSX everything blows up because without the React preset, it is considered to be a syntax error.

The fix is to selectively mock the `openModal` export from frontend-js-web to prevent the codepath that involves JSX from being exercised. Consider it a nasty hack, but a temporary one, because we will eventually get rid of all incremental-dom usage.