### PR TITLE
LPS-110926 Update sign-in modal usages

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/sign_in_modal.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/sign_in_modal.js
@@ -12,6 +12,11 @@
  * details.
  */
 
+/**
+ * Sign-in modal
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ */
+
 AUI.add(
 	'liferay-sign-in-modal',
 	A => {

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -21,6 +21,17 @@ import React, {useEffect, useRef, useState} from 'react';
 import './Modal.scss';
 
 const openModal = props => {
+	if (
+		props &&
+		props.url &&
+		props.bodyHTML &&
+		process.env.NODE_ENV === 'development'
+	) {
+		console.warn(
+			'url and bodyHTML props are both set. bodyHTML will be ignored. Please use one or another.'
+		);
+	}
+
 	// Mount in detached node; Clay will take care of appending to `document.body`.
 	// See: https://github.com/liferay/clay/blob/master/packages/clay-shared/src/Portal.tsx
 	render(Modal, props, document.createElement('div'));

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -16,7 +16,7 @@ import ClayButton from '@clayui/button';
 import ClayModal, {useModal} from '@clayui/modal';
 import {render} from 'frontend-js-react-web';
 import PropTypes from 'prop-types';
-import React, {useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 import './Modal.scss';
 
@@ -26,7 +26,7 @@ const openModal = props => {
 	render(Modal, props, document.createElement('div'));
 };
 
-const Modal = ({buttons, id, onClose, size, title, url}) => {
+const Modal = ({bodyHTML, buttons, id, onClose, size, title, url}) => {
 	const [visible, setVisible] = useState(true);
 
 	const {observer} = useModal({
@@ -93,6 +93,22 @@ const Modal = ({buttons, id, onClose, size, title, url}) => {
 		}
 	};
 
+	const BodyHTML = () => {
+		const bodyRef = useRef();
+
+		useEffect(() => {
+			const fragment = document
+				.createRange()
+				.createContextualFragment(bodyHTML);
+
+			bodyRef.current.innerHTML = '';
+
+			bodyRef.current.appendChild(fragment);
+		}, []);
+
+		return <div ref={bodyRef}></div>;
+	};
+
 	return (
 		<>
 			{visible && (
@@ -103,7 +119,9 @@ const Modal = ({buttons, id, onClose, size, title, url}) => {
 					size={url && !size ? 'full-screen' : size}
 				>
 					<ClayModal.Header>{title}</ClayModal.Header>
-					<ClayModal.Body url={getIframeUrl()} />
+					<ClayModal.Body url={getIframeUrl()}>
+						{bodyHTML && <BodyHTML />}
+					</ClayModal.Body>
 					{buttons && (
 						<ClayModal.Footer
 							last={
@@ -150,6 +168,7 @@ const Modal = ({buttons, id, onClose, size, title, url}) => {
 };
 
 Modal.propTypes = {
+	bodyHTML: PropTypes.string,
 	buttons: PropTypes.arrayOf(
 		PropTypes.shape({
 			displayType: PropTypes.oneOf([

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/modal/Modal.js
@@ -72,4 +72,20 @@ describe('Modal', () => {
 
 		expect(onCloseCallback).toBeCalled();
 	});
+
+	// We are skipping this test because Jest does not support
+	// document.createRange, but will support it in a future version. See more:
+	//
+	//      https://github.com/liferay/liferay-npm-tools/issues/440
+	it.skip('renders given body HTML', () => {
+		const sampleId = 'sampleId';
+
+		render(<Modal bodyHTML={`<div id='${sampleId}' />`} />);
+
+		act(() => {
+			jest.runAllTimers();
+		});
+
+		expect(document.getElementById(sampleId)).toBeTruthy();
+	});
 });

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/js/main.js
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/js/main.js
@@ -13,10 +13,36 @@
  */
 
 /* eslint-disable prefer-arrow-callback */
-AUI().ready('liferay-sign-in-modal', function(A) {
-	var signIn = A.one('.sign-in > a');
+(function() {
+	var signInLink = document.querySelector('.sign-in > a');
 
-	if (signIn && signIn.getData('redirect') !== 'true') {
-		signIn.plug(Liferay.SignInModal);
+	if (signInLink && signInLink.dataset.redirect === 'false') {
+		signInLink.addEventListener('click', function(event) {
+			event.preventDefault();
+
+			var modalSignInURL = Liferay.Util.addParams(
+				'windowState=exclusive',
+				signInLink.href
+			);
+
+			Liferay.Util.fetch(modalSignInURL)
+				.then(response => response.text())
+				.then(response => {
+					if (response) {
+						Liferay.Util.openModal({
+							bodyHTML: response,
+							title: Liferay.Language.get('sign-in'),
+						});
+					}
+					else {
+						redirectPage();
+					}
+				})
+				.catch(() => redirectPage());
+		});
 	}
-});
+
+	function redirectPage() {
+		window.location.href = signInLink.href;
+	}
+})();


### PR DESCRIPTION
Hey @wincent ,

This is a followup on https://github.com/wincent/liferay-portal/pull/208

Changes:
- Added a warning in the case both `url` and `bodyHTML` params are used
- Wrapped failing test in `it.skip`, along with comment linking it to https://github.com/liferay/liferay-npm-tools/issues/440

Please review the code.

Thank you!

/cc @jbalsas