### PR TITLE
LPS-101624, LPS-101625 Deprecate `Liferay.Util.isTablet` and `Liferay.Util.isPhone`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -803,18 +803,6 @@
 			return typeof val === 'function';
 		},
 
-		isPhone() {
-			var instance = this;
-
-			return instance.getWindowWidth() < Liferay.BREAKPOINTS.PHONE;
-		},
-
-		isTablet() {
-			var instance = this;
-
-			return instance.getWindowWidth() < Liferay.BREAKPOINTS.TABLET;
-		},
-
 		listCheckboxesExcept(form, except, name, checked) {
 			form = Util.getDOM(form);
 
@@ -1927,11 +1915,6 @@
 	Util.Window = Window;
 
 	Liferay.Util = Util;
-
-	Liferay.BREAKPOINTS = {
-		PHONE: 768,
-		TABLET: 980,
-	};
 
 	Liferay.STATUS_CODE = {
 		BAD_REQUEST: 400,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -31,6 +31,7 @@ export {cancelDebounce, debounce} from './liferay/debounce/debounce.es';
 export {default as objectToFormData} from './liferay/util/form/object_to_form_data.es';
 
 // Liferay API
+export {default as BREAKPOINTS} from './liferay/breakpoints';
 
 export {default as CompatibilityEventProxy} from './liferay/CompatibilityEventProxy.es';
 
@@ -69,4 +70,6 @@ export {default as throttle} from './liferay/throttle.es';
 // Util API
 
 export {default as fetch} from './liferay/util/fetch.es';
+export {default as isPhone} from './liferay/util/is_phone';
+export {default as isTablet} from './liferay/util/is_tablet';
 export {default as navigate} from './liferay/util/navigate.es';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/breakpoints.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/breakpoints.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default {
+	PHONE: 768,
+	TABLET: 980,
+};

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -65,7 +65,7 @@ import toCharCode from './util/to_char_code.es';
 Liferay = window.Liferay || {};
 
 /**
- * @deprecated As of Athanasius (7.3.x), replaced by `import BREAKPOINTS from 'frontend-js-web'`
+ * @deprecated As of Athanasius (7.3.x), replaced by `import {BREAKPOINTS} from 'frontend-js-web'`
  */
 Liferay.BREAKPOINTS = BREAKPOINTS;
 
@@ -119,12 +119,12 @@ Liferay.Util.groupBy = groupBy;
 Liferay.Util.isEqual = isEqual;
 
 /**
- * @deprecated As of Athanasius (7.3.x), replaced by `import isPhone from 'frontend-js-web'`
+ * @deprecated As of Athanasius (7.3.x), replaced by `import {isPhone} from 'frontend-js-web'`
  */
 Liferay.Util.isPhone = isPhone;
 
 /**
- * @deprecated As of Athanasius (7.3.x), replaced by `import isTablet from 'frontend-js-web'`
+ * @deprecated As of Athanasius (7.3.x), replaced by `import {isTablet} from 'frontend-js-web'`
  */
 Liferay.Util.isTablet = isTablet;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -17,6 +17,7 @@ import groupBy from 'lodash.groupby';
 import isEqual from 'lodash.isequal';
 import unescape from 'lodash.unescape';
 
+import BREAKPOINTS from './breakpoints';
 import {
 	component,
 	componentReady,
@@ -49,6 +50,8 @@ import formatStorage from './util/format_storage.es';
 import formatXML from './util/format_xml.es';
 import getCropRegion from './util/get_crop_region.es';
 import getPortletNamespace from './util/get_portlet_namespace.es';
+import isPhone from './util/is_phone';
+import isTablet from './util/is_tablet';
 import navigate from './util/navigate.es';
 import ns from './util/ns.es';
 import objectToURLSearchParams from './util/object_to_url_search_params.es';
@@ -60,6 +63,11 @@ import {getSessionValue, setSessionValue} from './util/session.es';
 import toCharCode from './util/to_char_code.es';
 
 Liferay = window.Liferay || {};
+
+/**
+ * @deprecated As of Athanasius (7.3.x), replaced by `import BREAKPOINTS from 'frontend-js-web'`
+ */
+Liferay.BREAKPOINTS = BREAKPOINTS;
 
 Liferay.component = component;
 Liferay.componentReady = componentReady;
@@ -109,6 +117,17 @@ Liferay.Util.getFormElement = getFormElement;
 Liferay.Util.getPortletNamespace = getPortletNamespace;
 Liferay.Util.groupBy = groupBy;
 Liferay.Util.isEqual = isEqual;
+
+/**
+ * @deprecated As of Athanasius (7.3.x), replaced by `import isPhone from 'frontend-js-web'`
+ */
+Liferay.Util.isPhone = isPhone;
+
+/**
+ * @deprecated As of Athanasius (7.3.x), replaced by `import isTablet from 'frontend-js-web'`
+ */
+Liferay.Util.isTablet = isTablet;
+
 Liferay.Util.navigate = navigate;
 Liferay.Util.ns = ns;
 Liferay.Util.objectToFormData = objectToFormData;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/is_phone.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/is_phone.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import BREAKPOINTS from '../breakpoints';
+
+export default function isPhone() {
+	return window.innerWidth < BREAKPOINTS.PHONE;
+}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/is_tablet.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/is_tablet.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import BREAKPOINTS from '../breakpoints';
+
+export default function isTablet() {
+	return window.innerWidth < BREAKPOINTS.TABLET;
+}


### PR DESCRIPTION
Originally discussed in [#206](https://github.com/wincent/liferay-portal/pull/206)

The goal of these changes is to mark `Liferay.Util.isTablet` and
`Liferay.Util.isPhone` as deprecated. We're also providing these
functions as "modules" so that they can easily be imported projects
that use ES6.

@wincent in case you're confused; you already reviewed this yesterday 
in [#213](https://github.com/wincent/liferay-portal/pull/213) and it was forwarded to [https://github.com/brianchandotcom/liferay-portal/pull/87789](https://github.com/brianchandotcom/liferay-portal/pull/87789), but based on [this](https://github.com/brianchandotcom/liferay-portal/pull/87789#issuecomment-616785319) 
comment, I updated the JSDoc `@deprecated` comments.