### PR TITLE
LPS-112180 Restore focus in "Extend Session" banner

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -643,10 +643,21 @@ AUI.add(
 					if (!instance._alertClosed) {
 						var banner = instance._getBanner();
 
+						var bannerFocused = banner.bodyNode.contains(
+							document.activeElement
+						);
+
 						banner.set(
 							'message',
 							Lang.sub(instance._warningText, [remainingTime])
 						);
+
+						if (bannerFocused) {
+							banner.bodyNode
+								.all('a')
+								.item(0)
+								.focus();
+						}
 					}
 
 					DOC.title =


### PR DESCRIPTION
Hi @wincent ,

Could you review this pull request, please?

The issue is described in [LPS-112180](https://issues.liferay.com/browse/LPS-112180), but just in case it helps you to understand it, every time the interval runs we [update](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js#L646-L649) our banner to show the updated time. That [ends up](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/alert.js#L231-L242) updating the whole body content of the banner and making us losing the focus in case it was part of that message (the button to extend the session is part of the message).

The solution is a bit tricky so feel free to improve it :P

Thanks.

Regards.