### PR TITLE
LPS-101643 Deprecate Liferay.Util.escapeCDATA

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -392,6 +392,9 @@
 			Util.toggleDisabled(inputs, false);
 		},
 
+		/**
+		 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+		 */
 		escapeCDATA(str) {
 			return str.replace(/<!\[CDATA\[|\]\]>/gi, match => {
 				var str = '';


### PR DESCRIPTION
The goal of this change is to mark the `Liferay.Util.escapeCDATA` function as
deprecated. Based on the conversations we've had in
https://github.com/wincent/liferay-portal/pull/210, we're still keeping the function to avoid breaking changes in case it's being used externally.
I couldn't find any internal usages (I searched using `git grep
escapeCDATA`), but here is a list of commits that are related:
https://github.com/liferay/liferay-portal/commit/37ae29c447253b56d3f5bd6e966b19872a6bdab0
https://github.com/liferay/liferay-portal/commit/be13362f3bc39b3c6825a49cea525398a78d1238
