### PR TITLE
LPS-112489 Standardize frontend deprecation annotations

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/autocomplete_input_caretindex.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/autocomplete_input_caretindex.js
@@ -15,7 +15,7 @@
 /**
  * The Autocomplete Input Caretindex Component.
  *
- * @deprecated since 7.2, unused
+ * @deprecated As of Mueller (7.2.x), with no direct replacement
  * @module liferay-autocomplete-input-caretindex
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/autocomplete_input_caretindex_sel.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/autocomplete_input_caretindex_sel.js
@@ -15,7 +15,7 @@
 /**
  * The Autocomplete Input Caretindex Sel Component.
  *
- * @deprecated since 7.2, unused
+ * @deprecated As of Mueller (7.2.x), with no direct replacement
  * @module liferay-autocomplete-input-caretindex-sel
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/autocomplete_input_caretoffset.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/autocomplete_input_caretoffset.js
@@ -15,7 +15,7 @@
 /**
  * The Autocomplete Input Caretoffset Component.
  *
- * @deprecated since 7.2, unused
+ * @deprecated As of Mueller (7.2.x), with no direct replacement
  * @module liferay-autocomplete-input-caretoffset
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/autocomplete_input_caretoffset_sel.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/autocomplete_input_caretoffset_sel.js
@@ -15,7 +15,7 @@
 /**
  * The Autocomplete Input Caretoffset Sel Component.
  *
- * @deprecated since 7.2, unused
+ * @deprecated As of Mueller (7.2.x), with no direct replacement
  * @module liferay-autocomplete-input-caretoffset-sel
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/autocomplete_textarea.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/autocomplete_textarea.js
@@ -15,7 +15,7 @@
 /**
  * The Autocomplete Textarea Component.
  *
- * @deprecated since 7.2, unused
+ * @deprecated As of Mueller (7.2.x), with no direct replacement
  * @module liferay-autocomplete-textarea
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/crop_region.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/crop_region.js
@@ -15,7 +15,7 @@
 /**
  * The Crop Region Utility
  *
- * @deprecated As of Athanasius(7.3.x), replaced by Liferay.Util.getCropRegion
+ * @deprecated As of Athanasius (7.3.x), replaced by Liferay.Util.getCropRegion
  * @module liferay-crop-region
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form.js
@@ -532,7 +532,7 @@ AUI.add(
 			},
 
 			/*
-			 * @deprecated since 7.2, unused
+			 * @deprecated As of Mueller (7.2.x), with no direct replacement
 			 */
 			register(config) {
 				var instance = this;

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form_placeholders.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/form_placeholders.js
@@ -15,7 +15,7 @@
 /**
  * The Form Placeholders Component.
  *
- * @deprecated since 7.2, unused
+ * @deprecated As of Mueller (7.2.x), with no direct replacement
  * @module liferay-form-placeholders
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/hudcrumbs.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/hudcrumbs.js
@@ -15,7 +15,7 @@
 /**
  * The Hudcrumbs Component.
  *
- * @deprecated since 7.2, unused
+ * @deprecated As of Mueller (7.2.x), with no direct replacement
  * @module liferay-hudcrumbs
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/icon.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/icon.js
@@ -15,7 +15,7 @@
 /**
  * The Icon Component.
  *
- * @deprecated since 7.2, unused
+ * @deprecated As of Mueller (7.2.x), with no direct replacement
  * @module liferay-icon
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_move_boxes_touch.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_move_boxes_touch.js
@@ -15,7 +15,7 @@
 /**
  * The Input Move Boxes Touch Component.
  *
- * @deprecated since 7.2, unused
+ * @deprecated As of Mueller (7.2.x), with no direct replacement
  * @module liferay-input-move-boxes-touch
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_selector_dialog.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_selector_dialog.js
@@ -13,7 +13,7 @@
  */
 
 /**
- * @deprecated As of Athanasius(7.3.x), replaced by ItemSelectorDialog.es.js
+ * @deprecated As of Athanasius (7.3.x), replaced by ItemSelectorDialog.es.js
  * @module liferay-item-selector-dialog
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_selector_dialog.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_selector_dialog.js
@@ -91,7 +91,7 @@ AUI.add(
 				},
 
 				/*
-				 * @deprecated since 7.2, unused
+				 * @deprecated As of Mueller (7.2.x), with no direct replacement
 				 */
 				close() {
 					var instance = this;

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_selector_repository_entry_browser.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_selector_repository_entry_browser.js
@@ -13,7 +13,7 @@
  */
 
 /**
- * @deprecated As of Athanasius(7.3.x), replaced by ItemSelectorRepositoryEntryBrowser.es.js
+ * @deprecated As of Athanasius (7.3.x), replaced by ItemSelectorRepositoryEntryBrowser.es.js
  * @module liferay-item-selector-repository-entry-browser
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_selector_url.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_selector_url.js
@@ -13,7 +13,7 @@
  */
 
 /**
- * @deprecated As of Athanasius(7.3.x), replaced by ItemSelectorUrl.es.js
+ * @deprecated As of Athanasius (7.3.x), replaced by ItemSelectorUrl.es.js
  * @module liferay-item-selector-url
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_viewer.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/item_viewer.js
@@ -13,7 +13,7 @@
  */
 
 /**
- * @deprecated As of Athanasius(7.3.x), replaced by ItemSelectorPreview.es.js
+ * @deprecated As of Athanasius (7.3.x), replaced by ItemSelectorPreview.es.js
  * @module liferay-item-viewer
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/list_view.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/list_view.js
@@ -15,7 +15,7 @@
 /**
  * The List View Component.
  *
- * @deprecated since 7.2, unused
+ * @deprecated As of Mueller (7.2.x), with no direct replacement
  * @module liferay-list-view
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/node.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/node.js
@@ -15,7 +15,7 @@
 /**
  * The Liferay Node Utility
  *
- * @deprecated As of Athanasius(7.3.x), with no direct replacement
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
  * @module liferay-node
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/notice.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/notice.js
@@ -33,7 +33,7 @@ AUI.add(
 		var STR_SHOW = 'show';
 
 		/**
-		 * @deprecated
+		 * @deprecated As of Wilberforce (7.0.x)
 		 *
 		 * OPTIONS
 		 *

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/pagination.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/pagination.js
@@ -15,7 +15,7 @@
 /**
  * The Pagination Component.
  *
- * @deprecated since 7.2, unused
+ * @deprecated As of Mueller (7.2.x), with no direct replacement
  * @module liferay-pagination
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/portlet_url.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/portlet_url.js
@@ -106,7 +106,7 @@ AUI.add(
 			},
 
 			/*
-			 * @deprecated
+			 * @deprecated As of Wilberforce (7.0.x)
 			 */
 
 			setCopyCurrentRenderParameters() {
@@ -132,7 +132,7 @@ AUI.add(
 			},
 
 			/*
-			 * @deprecated
+			 * @deprecated As of Wilberforce (7.0.x)
 			 */
 
 			setEncrypt() {
@@ -209,7 +209,7 @@ AUI.add(
 			},
 
 			/*
-			 * @deprecated
+			 * @deprecated As of Wilberforce (7.0.x)
 			 */
 
 			setPortletConfiguration() {
@@ -243,7 +243,7 @@ AUI.add(
 			},
 
 			/*
-			 * @deprecated since 7.2, unused
+			 * @deprecated As of Mueller (7.2.x), with no direct replacement
 			 */
 			setSecure(secure) {
 				var instance = this;

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/portlet_url.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/portlet_url.js
@@ -15,7 +15,7 @@
 /**
  * The Portlet URL Utility
  *
- * @deprecated As of Athanasius(7.3.x), replaced by Liferay.Util.PortletURL
+ * @deprecated As of Athanasius (7.3.x), replaced by Liferay.Util.PortletURL
  * @module liferay-portlet-url
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/preview.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/preview.js
@@ -15,7 +15,7 @@
 /**
  * The Preview Component.
  *
- * @deprecated since 7.2, unused
+ * @deprecated As of Mueller (7.2.x), with no direct replacement
  * @module liferay-preview
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/resize_rtl.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/resize_rtl.js
@@ -15,7 +15,7 @@
 /**
  * The Resize RTL Component.
  *
- * @deprecated since 7.2, unused
+ * @deprecated As of Mueller (7.2.x), with no direct replacement
  * @module liferay-resize-rtl
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/restore_entry.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/restore_entry.js
@@ -15,7 +15,7 @@
 /**
  * The Restore Entry Component.
  *
- * @deprecated since 7.2, unused
+ * @deprecated As of Mueller (7.2.x), with no direct replacement
  * @module liferay-restore-entry
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/social_bookmarks.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/social_bookmarks.js
@@ -15,7 +15,7 @@
 /**
  * The Social Bookmarks Component.
  *
- * @deprecated
+ * @deprecated As of Mueller (7.2.x)
  * @module liferay-social-bookmarks
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/sortable.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/sortable.js
@@ -15,7 +15,7 @@
 /**
  * The Sortable Component.
  *
- * @deprecated since 7.2, unused
+ * @deprecated As of Mueller (7.2.x), with no direct replacement
  * @module liferay-sortable
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/storage_formatter.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/storage_formatter.js
@@ -15,7 +15,7 @@
 /**
  * The Storage Formatter Utility
  *
- * @deprecated As of Athanasius(7.3.x), replaced by Liferay.Util.formatStorage
+ * @deprecated As of Athanasius (7.3.x), replaced by Liferay.Util.formatStorage
  * @module liferay-storage-formatter
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/store.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/store.js
@@ -15,7 +15,7 @@
 /**
  * The Store Utility
  *
- * @deprecated As of Athanasius(7.3.x), replaced by Liferay.Util.Session
+ * @deprecated As of Athanasius (7.3.x), replaced by Liferay.Util.Session
  * @module liferay-store
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/token_list.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/token_list.js
@@ -15,7 +15,7 @@
 /**
  * The Token List Component.
  *
- * @deprecated since 7.2, unused
+ * @deprecated As of Mueller (7.2.x), with no direct replacement
  * @module liferay-token-list
  */
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/xml_formatter.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/xml_formatter.js
@@ -15,7 +15,7 @@
 /**
  * The XML Formatter Utility
  *
- * @deprecated As of Athanasius(7.3.x), replaced by Liferay.Util.formatXML
+ * @deprecated As of Athanasius (7.3.x), replaced by Liferay.Util.formatXML
  * @module liferay-xml-formatter
  */
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/PortletBase.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/PortletBase.es.js
@@ -167,7 +167,7 @@ PortletBase.STATE = {
 	/**
 	 * Portlet's namespace.
 	 *
-	 * @deprecated since 7.1
+	 * @deprecated As of Judson (7.1.x)
 	 * @instance
 	 * @memberof PortletBase
 	 * @type {string}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/PortletBase.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/PortletBase.es.js
@@ -52,7 +52,7 @@ class PortletBase extends Component {
 	/**
 	 * Performs an HTTP POST request to the given URL with the given body.
 	 *
-	 * @deprecated since 7.3, use <code>Liferay.Util.fetch</code>.
+	 * @deprecated As of Athanasius (7.3.x), replaced by `Liferay.Util.fetch`.
 	 * @param      {!string} url The URL to send the post request to.
 	 * @param      {!Object|!FormData} body The request body.
 	 * @return     {Promise} A promise.


### PR DESCRIPTION
We have [a lint](https://github.com/liferay/eslint-config-liferay/pull/175) for making sure all frontend deprecation notices follow the standard pattern. I'll be shipping that as soon as https://github.com/brianchandotcom/liferay-portal/pull/87959 goes in (may already be in by the time you read this).

In the meantime, there are some deprecation notices that require manual review, so I am preparing these fixes ahead of time. Half of these are fully automated fixes; the other half I had to do some manual digging first to provide minimal information, and then I let the linter format them correctly.