### PR TITLE
LPS-101644 Deprecate `Liferay.Util.disableEsc`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -293,12 +293,6 @@
 			}
 		},
 
-		disableEsc() {
-			if (document.all && window.event.keyCode == 27) {
-				window.event.returnValue = false;
-			}
-		},
-
 		disableFormButtons(inputs, form) {
 			inputs.attr('disabled', true);
 			inputs.setStyle('opacity', 0.5);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -119,7 +119,7 @@ Liferay.Util.addParams = addParams;
  * @deprecated As of Athanasius (7.3.x), with no direct replacement
  */
 Liferay.Util.disableEsc = () => {
-	if (document.all && window.event.keyCode == 27) {
+	if (document.all && window.event.keyCode === 27) {
 		window.event.returnValue = false;
 	}
 };

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -115,6 +115,15 @@ Liferay.Util = Liferay.Util || {};
  */
 Liferay.Util.addParams = addParams;
 
+/**
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ */
+Liferay.Util.disableEsc = () => {
+	if (document.all && window.event.keyCode == 27) {
+		window.event.returnValue = false;
+	}
+};
+
 Liferay.Util.escape = escape;
 Liferay.Util.fetch = fetch;
 Liferay.Util.formatStorage = formatStorage;


### PR DESCRIPTION
The goal of this change is to mark the `Liferay.Util.disableEsc`
function as deprecated.

This function is used in a few places:

In the `archived` directory, which we don't want to update, but don't want to
break either
https://github.com/liferay/liferay-portal/blob/1991cde6e2f3ef10689a7b32c819cd91cf9faa55/modules/apps/archived/flash-web/src/main/resources/META-INF/resources/configuration.jsp#L61
https://github.com/liferay/liferay-portal/blob/1991cde6e2f3ef10689a7b32c819cd91cf9faa55/modules/apps/archived/web-proxy-web/src/main/resources/META-INF/resources/configuration.jsp#L56

And in current modules that are still "active"
https://github.com/liferay/liferay-portal/blob/aba1c8126c487579a96eeddd977f1f1ecd91ae3b/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/configuration.jsp#L144
https://github.com/liferay/liferay-portal/blob/3750e154e3b73509e0cda8c5f77ebb47a099b4de/portal-web/docroot/html/taglib/ui/input_field/page.jsp#L520
https://github.com/liferay/liferay-portal/blob/3750e154e3b73509e0cda8c5f77ebb47a099b4de/portal-web/docroot/html/taglib/ui/input_field/page.jsp#L529

For now, marking this function as deprecated seems like the safest
option, in the future if we wan't to disable the "escape" key, it might
be worth relying on something else than `window.event.returnValue`, as
it doesn't seem to be supported in Firefox as mentioned here
https://developer.mozilla.org/en-US/docs/Web/API/Event/returnValue