### PR TITLE
LPS-112623 Update formik to v2.1.4

### DIFF
--- a/modules/apps/frontend-js/frontend-js-react-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-react-web/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"@clayui/icon": "3.0.5",
 		"classnames": "2.2.6",
-		"formik": "1.4.3",
+		"formik": "2.1.4",
 		"prop-types": "15.7.2",
 		"react": "16.12.0",
 		"react-dnd": "10.0.1",

--- a/modules/apps/segments/segments-web/package.json
+++ b/modules/apps/segments/segments-web/package.json
@@ -9,7 +9,7 @@
 		"@clayui/loading-indicator": "3.0.2",
 		"classnames": "2.2.6",
 		"date-fns": "^1.30.1",
-		"formik": "1.4.3",
+		"formik": "2.1.4",
 		"frontend-js-web": "*",
 		"metal": "2.16.8",
 		"odata-v4-parser": "^0.1.29",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -6163,7 +6163,7 @@ create-react-context@<=0.2.2:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
-create-react-context@^0.2.1, create-react-context@^0.2.2:
+create-react-context@^0.2.1:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
   integrity sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==
@@ -7013,7 +7013,7 @@ discontinuous-range@1.0.0:
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
   integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
 
-dnd-core@10.0.1, dnd-core@^10.0.1:
+dnd-core@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-10.0.1.tgz#151d95cd3a7fa47b210905c301364c0828203029"
   integrity sha512-PokpWzFSKbpmJSWbSIfVJtIsRdx3DP5e3//agNNzV8L1k9T4/IFKtgjjwKeLKmP9qMuTXdZZGSS40w+eZ8MmUg==
@@ -8416,20 +8416,19 @@ format@^0.2.2:
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
 
-formik@1.4.3:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/formik/-/formik-1.4.3.tgz#a3bece72f545981f8fc825c21d5292d9aac524d2"
-  integrity sha512-rwwcCPhidgiACnh1RBY8vp+Zp9ompHxezuGeIqmOh9RvmNCB8GCupoCWdDkWB0DZ1MBoDl76swB2v/FbMxeEmw==
+formik@2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.1.4.tgz#8deef07ec845ea98f75e03da4aad7aab4ac46570"
+  integrity sha512-oKz8S+yQBzuQVSEoxkqqJrKQS5XJASWGVn6mrs+oTWrBoHgByVwwI1qHiVc9GKDpZBU9vAxXYAKz2BvujlwunA==
   dependencies:
-    create-react-context "^0.2.2"
     deepmerge "^2.1.1"
-    hoist-non-react-statics "^2.5.5"
-    lodash "^4.17.11"
-    lodash-es "^4.17.11"
-    prop-types "^15.6.1"
+    hoist-non-react-statics "^3.3.0"
+    lodash "^4.17.14"
+    lodash-es "^4.17.14"
     react-fast-compare "^2.0.1"
+    scheduler "^0.18.0"
     tiny-warning "^1.0.2"
-    tslib "^1.9.3"
+    tslib "^1.10.0"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -9403,7 +9402,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.5:
+hoist-non-react-statics@^2.3.1:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
@@ -11776,6 +11775,11 @@ lodash-es@^4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
   integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
+
+lodash-es@^4.17.14:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
 lodash._basecopy@^3.0.0:
   version "3.0.1"
@@ -16887,11 +16891,6 @@ string.prototype.padstart@^3.0.0:
     es-abstract "^1.4.3"
     function-bind "^1.0.2"
 
-string.prototype.startswith@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/string.prototype.startswith/-/string.prototype.startswith-0.2.0.tgz#da68982e353a4e9ac4a43b450a2045d1c445ae7b"
-  integrity sha1-2miYLjU6TprEpDtFCiBF0cRFrns=
-
 string.prototype.trim@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.0.tgz#75a729b10cfc1be439543dae442129459ce61e3d"
@@ -17719,6 +17718,11 @@ ts-pnp@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.2.tgz#be8e4bfce5d00f0f58e0666a82260c34a57af552"
   integrity sha512-f5Knjh7XCyRIzoC/z1Su1yLLRrPrFCgtUAh/9fCSP6NKbATwpOL1+idQVXQokK9GRFURn/jYPGPfegIctwunoA==
+
+tslib@^1.10.0:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
+  integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
 
 tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -1022,7 +1022,7 @@
     "@clayui/icon" "^3.0.5"
     classnames "^2.2.6"
 
-"@clayui/autocomplete@3.1.3":
+"@clayui/autocomplete@3.1.3", "@clayui/autocomplete@^3.1.2":
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/@clayui/autocomplete/-/autocomplete-3.1.3.tgz#6cd00e293bf21449ce64c77a9647fb26c341142c"
   integrity sha512-uDmb9Cb9r3kmM5Y9Hvz33jUsyPI2GV14NoTdVmHz3hvOWYhGbSgLPkX4O5Qj7B5SCmP1EFfq+QHGLHsrEnR7PQ==
@@ -1030,16 +1030,6 @@
     "@clayui/drop-down" "^3.4.2"
     "@clayui/form" "^3.7.1"
     "@clayui/loading-indicator" "^3.0.2"
-    fuzzy "^0.1.3"
-
-"@clayui/autocomplete@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@clayui/autocomplete/-/autocomplete-3.1.2.tgz#3199ea0222102cdee8215e06e226bfc0ac040abb"
-  integrity sha512-3F76N01siAT4DRTc6sU4qc3oCaCXJsU5GxnYzaLH7T89MlbBXGRfwkLkwd9ha+Z+/tUnhMQWOAOYJtpTS+guXg==
-  dependencies:
-    "@clayui/drop-down" "^3.4.1"
-    "@clayui/form" "^3.7.0"
-    "@clayui/loading-indicator" "^3.0.1"
     fuzzy "^0.1.3"
 
 "@clayui/badge@3.0.2":
@@ -1062,20 +1052,12 @@
     classnames "^2.2.6"
     warning "^4.0.3"
 
-"@clayui/button@3.3.1", "@clayui/button@^3.3.1":
+"@clayui/button@3.3.1", "@clayui/button@^3.3.0", "@clayui/button@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@clayui/button/-/button-3.3.1.tgz#6d09a8b38e04b0b25d0f271f77e3bdfe9b6c8ecd"
   integrity sha512-HIG5V+jIN9cK0gefqc1tDOcszplCVGMTlXs1sKuPwclMLoFcHwqbmdZ2CEyVvZrjYt4IrZ8/OTYpDodZKRBXfA==
   dependencies:
     "@clayui/icon" "^3.0.5"
-    classnames "^2.2.6"
-
-"@clayui/button@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@clayui/button/-/button-3.3.0.tgz#f8be387a44450b3d7745504bd0cb57955effd860"
-  integrity sha512-6j7CB7VxpxPuGzgj7jGTC+28plLOV5HBrKTxgbKnxXYJoqLc4lfiG49amh1L7LQ+9ZGthnCCdMxt1HK40XmMPA==
-  dependencies:
-    "@clayui/icon" "^3.0.4"
     classnames "^2.2.6"
 
 "@clayui/card@3.2.0":
@@ -1138,7 +1120,7 @@
     classnames "^2.2.6"
     moment "^2.22.2"
 
-"@clayui/drop-down@3.4.2", "@clayui/drop-down@^3.4.2":
+"@clayui/drop-down@3.4.2", "@clayui/drop-down@^3.4.1", "@clayui/drop-down@^3.4.2":
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/@clayui/drop-down/-/drop-down-3.4.2.tgz#8aa3d4d44e9b991a145e5ced10398a4e80b4231c"
   integrity sha512-/5e4SNhNcg0bD0vQDD7YDqEIYKgLqyIr4dMFJmrkosXXObbZiBo0NT58qW+r8H8QKwRtye/fAXMZ9A7SgtyoCQ==
@@ -1152,20 +1134,6 @@
     dom-align "^1.10.2"
     warning "^4.0.3"
 
-"@clayui/drop-down@^3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@clayui/drop-down/-/drop-down-3.4.1.tgz#dc3ae21a1ae27922f1d22ade81f72bfc4452a959"
-  integrity sha512-mBx09bQs6p83nc+f2SCLX9sULfzw7xIZqWBqthN5xfnPd98f0HY4PWsb7Tb3hSIg5twGQDoJgSuoCIIoTsmbOQ==
-  dependencies:
-    "@clayui/button" "^3.3.0"
-    "@clayui/form" "^3.7.0"
-    "@clayui/icon" "^3.0.4"
-    "@clayui/link" "^3.1.0"
-    "@clayui/shared" "^3.1.0"
-    classnames "^2.2.6"
-    dom-align "^1.10.2"
-    warning "^4.0.3"
-
 "@clayui/empty-state@3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@clayui/empty-state/-/empty-state-3.1.0.tgz#a4ff017f4f98f27a17c2bcf2c1e5498b34b4edda"
@@ -1173,7 +1141,7 @@
   dependencies:
     classnames "^2.2.6"
 
-"@clayui/form@3.7.1", "@clayui/form@^3.7.1":
+"@clayui/form@3.7.1", "@clayui/form@^3.7.0", "@clayui/form@^3.7.1":
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/@clayui/form/-/form-3.7.1.tgz#87d700f2fee9c2fd5941e830205c4b6a37462ef8"
   integrity sha512-bXlmPcvnRtvXP3OuD0Ym4c5SgHHRjHICn3rUBKgXcIJs9wuVz+wBX7XmjXCPEEhTAeWzf97UOuaXxJlevRlvPA==
@@ -1182,16 +1150,7 @@
     "@clayui/icon" "^3.0.5"
     classnames "^2.2.6"
 
-"@clayui/form@^3.7.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@clayui/form/-/form-3.7.0.tgz#c870c75f42080d1a6707deece41f1e6846ccf0b9"
-  integrity sha512-AU4BS5/k3h3TRPsXCFsO16are3M3WaBzskjdTrezEOrudUAm3yrnXEdg5S7zpQ9X+TAa7sN/HCyAH/r5pE7iDw==
-  dependencies:
-    "@clayui/button" "^3.3.0"
-    "@clayui/icon" "^3.0.4"
-    classnames "^2.2.6"
-
-"@clayui/icon@3.0.5", "@clayui/icon@^3.0.5":
+"@clayui/icon@3.0.5", "@clayui/icon@^3.0.4", "@clayui/icon@^3.0.5":
   version "3.0.5"
   resolved "https://registry.yarnpkg.com/@clayui/icon/-/icon-3.0.5.tgz#e491476d2c10f1780b2bc1655b796b6058434abf"
   integrity sha512-djFEe7Zgk4H8o+Qk3VSjWsIAyI1XQ2O9lw8lfAYtYH739xt0y5NpgDWEOWaIBjvS/ou+rUi2VOVUuRAg9N6KVQ==
@@ -1199,15 +1158,7 @@
     classnames "^2.2.6"
     warning "^4.0.3"
 
-"@clayui/icon@^3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@clayui/icon/-/icon-3.0.4.tgz#f4b04e23c97163021b5665208f7d7c711f44918c"
-  integrity sha512-X5N1DqiPMwi5soYxbNgqC/asn/FDigRxHLjc785i7WfE6xdUpcTjvdJhGFx+Xgoign8NpNbVo5NZATHZLCLiFw==
-  dependencies:
-    classnames "^2.2.6"
-    warning "^4.0.3"
-
-"@clayui/label@3.3.0", "@clayui/label@^3.3.0":
+"@clayui/label@3.3.0", "@clayui/label@^3.2.0", "@clayui/label@^3.3.0":
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/@clayui/label/-/label-3.3.0.tgz#b9cb7629f185929d87dcf4c963d3370359602d9e"
   integrity sha512-s06k1ruqzNiRhHXVCo5ffRSqm7cFgcyfSsxbdaqDzVG+69xU/VPrBfHiUmporVAh/DE9V3N/diDlIPk+3HsnLQ==
@@ -1216,26 +1167,10 @@
     "@clayui/link" "^3.1.1"
     classnames "^2.2.6"
 
-"@clayui/label@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@clayui/label/-/label-3.2.0.tgz#2017fe15da8c64c305962bc9ce65f41d6cc2ab45"
-  integrity sha512-H7hyvmxiViNuB3Kp4hHOM2uh4qGw0g0jGw5s5QzwybUZU8DX8Hv4tEDmeQIblrwDXyiKwadQIIQ/IJwHH5IOQQ==
-  dependencies:
-    "@clayui/icon" "^3.0.4"
-    "@clayui/link" "^3.1.0"
-    classnames "^2.2.6"
-
-"@clayui/link@3.1.1", "@clayui/link@^3.1.1":
+"@clayui/link@3.1.1", "@clayui/link@^3.1.0", "@clayui/link@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@clayui/link/-/link-3.1.1.tgz#b4f454a0f9a45d132435f2168041eb2df2a77ba5"
   integrity sha512-9ITqLGZfw48E30/V/X2mJK5sK1FKL/p/QTkqZBf4NvUkP5ZuDR7fZGaT7GUCsyLFXWuumDe7+jJiMgUbzipu8g==
-  dependencies:
-    classnames "^2.2.6"
-
-"@clayui/link@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@clayui/link/-/link-3.1.0.tgz#b0213d9a5df7bf6d2bb6f15bd73fa69d2b3e0eb4"
-  integrity sha512-FEvQFF5hKCdckASHjbMtPw6zI6NacoFTiIZNN00tMN47j/cPfooizbCFx8fqj16F9lpx2Tz78rhW9SH6EFdu1A==
   dependencies:
     classnames "^2.2.6"
 
@@ -1252,17 +1187,10 @@
     "@clayui/sticker" "^3.1.1"
     classnames "^2.2.6"
 
-"@clayui/loading-indicator@3.0.2", "@clayui/loading-indicator@^3.0.2":
+"@clayui/loading-indicator@3.0.2", "@clayui/loading-indicator@^3.0.1", "@clayui/loading-indicator@^3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@clayui/loading-indicator/-/loading-indicator-3.0.2.tgz#4bdcc273f077ce83b818cf3b14ffd0b3de40c71d"
   integrity sha512-tJFqNsAgEQK20yHJtahtW7K/D/Z34syGE3TD/uEs5+tDPRjcpIi0zjPlay1QP5bBl5KoNvr8/qgTppWHzf/4wg==
-  dependencies:
-    classnames "^2.2.6"
-
-"@clayui/loading-indicator@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@clayui/loading-indicator/-/loading-indicator-3.0.1.tgz#a5e9e9e5f1536ee6c94423007029ecfb0940f57e"
-  integrity sha512-KQIt3ie+OYBgJj4KFLBc2YBliiGaJp9wBzgsPj9rkSzHMhWrMEOezxgoUorMpIl8vXDybaHw/lDM2cWmnA6llQ==
   dependencies:
     classnames "^2.2.6"
 
@@ -1339,7 +1267,7 @@
     "@clayui/shared" "^3.1.0"
     classnames "^2.2.6"
 
-"@clayui/pagination@3.1.3":
+"@clayui/pagination@3.1.3", "@clayui/pagination@^3.1.2":
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/@clayui/pagination/-/pagination-3.1.3.tgz#e0dfbefb945b58349f3ba870a949c0b798b976d3"
   integrity sha512-VbYtwbxl8CpyUd/lc8i5dB7jEbu2xZh2atNoCIZ9WNb2TvNv3ugW6Nt425PIof8R36EVhw/V5K4415zDCq07Ig==
@@ -1349,18 +1277,6 @@
     "@clayui/icon" "^3.0.5"
     "@clayui/link" "^3.1.1"
     "@clayui/shared" "^3.1.1"
-    classnames "^2.2.6"
-
-"@clayui/pagination@^3.1.2":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@clayui/pagination/-/pagination-3.1.2.tgz#b72111941697d6a4c9fa5077d64483c6e2040133"
-  integrity sha512-Funr3IIMlC0hVWgTGUuN/ElwIg/87oQFs4KokM+c4TnhJTHS8YRppspS2FMOfvT9zqv1ut/m3iqdflu3Pucuwg==
-  dependencies:
-    "@clayui/button" "^3.3.0"
-    "@clayui/drop-down" "^3.4.1"
-    "@clayui/icon" "^3.0.4"
-    "@clayui/link" "^3.1.0"
-    "@clayui/shared" "^3.1.0"
     classnames "^2.2.6"
 
 "@clayui/panel@3.2.0":
@@ -1390,21 +1306,13 @@
     classnames "^2.2.6"
     warning "^4.0.3"
 
-"@clayui/shared@3.1.1", "@clayui/shared@^3.1.1":
+"@clayui/shared@3.1.1", "@clayui/shared@^3.1.0", "@clayui/shared@^3.1.1":
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@clayui/shared/-/shared-3.1.1.tgz#91e8335a4c13b52217c6473f29fa5e322bc6df82"
   integrity sha512-+5IXSL6d01zDKiOa9WMAdAb2cAhEjwI89ksvxCrDCZDhpVyXvljTZreu3Z322caA+WN9+Pt6gn/O4N1PcdLroQ==
   dependencies:
     "@clayui/button" "^3.3.1"
     "@clayui/link" "^3.1.1"
-
-"@clayui/shared@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@clayui/shared/-/shared-3.1.0.tgz#616dd64c9f4208b686c2a9f221866d078b5b66f9"
-  integrity sha512-6mpCzCwKfK9LewqUKphee8bTHDSaWGK1/GoFTUgGHvKRNB97VZoS3ZA27QWI9LRHZvLlgbaOmwc1Pfr9zhpbkw==
-  dependencies:
-    "@clayui/button" "^3.3.0"
-    "@clayui/link" "^3.1.0"
 
 "@clayui/slider@3.1.1":
   version "3.1.1"
@@ -1435,7 +1343,7 @@
     "@clayui/shared" "^3.1.1"
     classnames "^2.2.6"
 
-"@clayui/time-picker@3.1.2":
+"@clayui/time-picker@3.1.2", "@clayui/time-picker@^3.1.1":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@clayui/time-picker/-/time-picker-3.1.2.tgz#ccba6740059f1497e77a7e3db34f7d8ae15141bf"
   integrity sha512-ngbsu8Oq7gDRwt+HHBGyrMc7mEy733HHIzZQhTDkRVxJK04mGX5b3X1B5K3SA2dEHG76DCqqHXtr1Ew2a6sAyw==
@@ -1444,17 +1352,6 @@
     "@clayui/form" "^3.7.1"
     "@clayui/icon" "^3.0.5"
     "@clayui/shared" "^3.1.1"
-    classnames "^2.2.6"
-
-"@clayui/time-picker@^3.1.1":
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/@clayui/time-picker/-/time-picker-3.1.1.tgz#88b0016264f96d55b77a31bd2b2bd678217f72bb"
-  integrity sha512-+4mvt5az+v388LhzvwbgbOPXGFf28IGZG/3KjH/JiaBN5rxxfGu3Okrjf8vNvzKhMX2nqe+J/r5rtLfWjuE+ag==
-  dependencies:
-    "@clayui/button" "^3.3.0"
-    "@clayui/form" "^3.7.0"
-    "@clayui/icon" "^3.0.4"
-    "@clayui/shared" "^3.1.0"
     classnames "^2.2.6"
 
 "@clayui/tooltip@3.2.3":
@@ -5058,29 +4955,10 @@ cheerio@^1.0.0-rc.2:
     lodash "^4.15.0"
     parse5 "^3.0.1"
 
-chokidar@^2.0.0:
+chokidar@^2.0.0, chokidar@^2.0.2, chokidar@^2.0.3, chokidar@^2.0.4, chokidar@^2.1.6:
   version "2.1.8"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
   integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
-  dependencies:
-    anymatch "^2.0.0"
-    async-each "^1.0.1"
-    braces "^2.3.2"
-    glob-parent "^3.1.0"
-    inherits "^2.0.3"
-    is-binary-path "^1.0.0"
-    is-glob "^4.0.0"
-    normalize-path "^3.0.0"
-    path-is-absolute "^1.0.0"
-    readdirp "^2.2.1"
-    upath "^1.1.1"
-  optionalDependencies:
-    fsevents "^1.2.7"
-
-chokidar@^2.0.2, chokidar@^2.0.3, chokidar@^2.0.4, chokidar@^2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.6.tgz#b6cad653a929e244ce8a834244164d241fa954c5"
-  integrity sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==
   dependencies:
     anymatch "^2.0.0"
     async-each "^1.0.1"
@@ -5287,15 +5165,10 @@ clay-component@2.21.2, clay-component@^2.21.2:
     metal-dom "^2.16.0"
     metal-state "^2.16.0"
 
-clay-css@2.21.2:
+clay-css@2.21.2, clay-css@^2.11.1:
   version "2.21.2"
   resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.21.2.tgz#3a572cd05d5f980dc049280a9f5dad2367f6aeaf"
   integrity sha512-Sv4L6Ms7uh/qSb+Hv8YvyvYg+N7kZdRlgdLbpQQiKCA0jFgLC+gofmDMWHNng6zh8JjEpW4RlA3jiHQeOIIRMw==
-
-clay-css@^2.11.1:
-  version "2.21.0"
-  resolved "https://registry.yarnpkg.com/clay-css/-/clay-css-2.21.0.tgz#96f96db5bb9631b6d493065b742626413b7ade80"
-  integrity sha512-4U9jDSzH2cAIoMgaxI/35qCPtWdfqviDFYHdXzKJG21WeBUyxnZV8Lm/I92Y3o7e42JNTY6rHYr3XQzuwZu78w==
 
 clay-data-provider@2.21.2, clay-data-provider@^2.21.2:
   version "2.21.2"
@@ -7013,7 +6886,7 @@ discontinuous-range@1.0.0:
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
   integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
 
-dnd-core@^10.0.1:
+dnd-core@10.0.1, dnd-core@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-10.0.1.tgz#151d95cd3a7fa47b210905c301364c0828203029"
   integrity sha512-PokpWzFSKbpmJSWbSIfVJtIsRdx3DP5e3//agNNzV8L1k9T4/IFKtgjjwKeLKmP9qMuTXdZZGSS40w+eZ8MmUg==
@@ -11771,12 +11644,7 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash-es@^4.17.11:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
-  integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
-
-lodash-es@^4.17.14:
+lodash-es@^4.17.11, lodash-es@^4.17.14:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
@@ -15848,14 +15716,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.3.2, resolve@^1.8.1:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.0.tgz#1b7ca96073ebb52e741ffd799f6b39ea462c67f5"
-  integrity sha512-+hTmAldEGE80U2wJJDC1lebb5jWqvTYAfm3YZ1ckk1gBr0MnCqUKlwK1e+anaFljIl+F5tR5IoZcm4ZDA1zMQw==
-  dependencies:
-    path-parse "^1.0.6"
-
-resolve@^1.15.1, resolve@^1.4.0:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.12.0, resolve@^1.14.2, resolve@^1.15.1, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.16.1.tgz#49fac5d8bacf1fd53f200fa51247ae736175832c"
   integrity sha512-rmAglCSqWWMrrBv/XM6sW0NuRFiKViw/W4d9EbC4pt+49H8JwHy+mcGmALTEg504AUDcLTvb1T2q3E9AnmY+ig==
@@ -17719,15 +17580,10 @@ ts-pnp@^1.1.2:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.2.tgz#be8e4bfce5d00f0f58e0666a82260c34a57af552"
   integrity sha512-f5Knjh7XCyRIzoC/z1Su1yLLRrPrFCgtUAh/9fCSP6NKbATwpOL1+idQVXQokK9GRFURn/jYPGPfegIctwunoA==
 
-tslib@^1.10.0:
+tslib@^1.10.0, tslib@^1.9.0, tslib@^1.9.3:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
   integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
-
-tslib@^1.9.0, tslib@^1.9.3:
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
-  integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
Upgrading because [we want a version of formik](https://github.com/liferay/liferay-frontend-guidelines/issues/40#issuecomment-619014725) that we can use in conjunction with React hooks.

Currently we are only using formik in one place (segments-web), and we don't believe any of the issues noted in [the v2 migration guide](https://github.com/jaredpalmer/formik/blob/master/packages/formik/MIGRATING-v2.md) will affect us.