### PR TITLE
LPS-101645 Deprecate `Liferay.Util.focusFormField`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -354,75 +354,6 @@
 			});
 		},
 
-		focusFormField(el) {
-			let interacting = false;
-
-			el = Util.getElement(el);
-
-			const handler = () => {
-				interacting = true;
-
-				document.body.removeEventListener('click', handler);
-			};
-
-			document.body.addEventListener('click', handler);
-
-			if (!interacting && Util.inBrowserView(el)) {
-				const getDisabledParents = function (el) {
-					let result = [];
-
-					if (el.parentElement) {
-						if (el.parentElement.getAttribute('disabled')) {
-							result = [el.parentElement];
-						}
-
-						result = [
-							...result,
-							...getDisabledParents(el.parentElement),
-						];
-					}
-
-					return result;
-				};
-
-				const disabledParents = getDisabledParents(el);
-
-				const focusable =
-					!el.getAttribute('disabled') &&
-					el.offsetWidth > 0 &&
-					el.offsetHeight > 0 &&
-					!disabledParents.length;
-
-				const form = el.closest('form');
-
-				if (!form || focusable) {
-					el.focus();
-				}
-				else if (form) {
-					const portletName = form.getAttribute('data-fm-namespace');
-
-					const formReadyEventName = portletName + 'formReady';
-
-					const formReadyHandler = (event) => {
-						const elFormName = form.getAttribute('name');
-
-						const formName = event.formName;
-
-						if (elFormName === formName) {
-							el.focus();
-
-							Liferay.detach(
-								formReadyEventName,
-								formReadyHandler
-							);
-						}
-					};
-
-					Liferay.on(formReadyEventName, formReadyHandler);
-				}
-			}
-		},
-
 		forcePost(link) {
 			const currentElement = Util.getElement(link);
 
@@ -494,24 +425,6 @@
 			var columnId = str.replace(/layout-column_/, '');
 
 			return columnId;
-		},
-
-		getDOM(el) {
-			if (el._node || el._nodes) {
-				el = el.getDOM();
-			}
-
-			return el;
-		},
-
-		getElement(el) {
-			const currentElement = Util.getDOM(el);
-
-			return typeof currentElement === 'string'
-				? document.querySelector(currentElement)
-				: currentElement.jquery
-				? currentElement[0]
-				: currentElement;
 		},
 
 		getGeolocation(success, fallback, options) {
@@ -669,77 +582,6 @@
 		 */
 		getWindowWidth() {
 			return window.innerWidth;
-		},
-
-		inBrowserView(node, win, nodeRegion) {
-			let viewable = false;
-
-			node = Util.getElement(node);
-
-			if (node) {
-				if (!nodeRegion) {
-					nodeRegion = node.getBoundingClientRect();
-
-					nodeRegion = {
-						left: nodeRegion.left + window.scrollX,
-						top: nodeRegion.top + window.scrollY,
-					};
-
-					nodeRegion.bottom = nodeRegion.top + node.offsetHeight;
-					nodeRegion.right = nodeRegion.left + node.offsetWidth;
-				}
-
-				if (!win) {
-					win = window;
-				}
-
-				win = Util.getElement(win);
-
-				const winRegion = {};
-
-				winRegion.left = win.scrollX;
-				winRegion.right = winRegion.left + win.innerWidth;
-
-				winRegion.top = win.scrollY;
-				winRegion.bottom = winRegion.top + win.innerHeight;
-
-				viewable =
-					nodeRegion.bottom <= winRegion.bottom &&
-					nodeRegion.left >= winRegion.left &&
-					nodeRegion.right <= winRegion.right &&
-					nodeRegion.top >= winRegion.top;
-
-				if (viewable) {
-					const frameEl = win.frameElement;
-
-					if (frameEl) {
-						let frameOffset = frameEl.getBoundingClientRect();
-
-						frameOffset = {
-							left: frameOffset.left + window.scrollX,
-							top: frameOffset.top + window.scrollY,
-						};
-
-						var xOffset = frameOffset.left - winRegion.left;
-
-						nodeRegion.left += xOffset;
-						nodeRegion.right += xOffset;
-
-						var yOffset = frameOffset.top - winRegion.top;
-
-						nodeRegion.top += yOffset;
-						nodeRegion.bottom += yOffset;
-
-						viewable = Util.inBrowserView(
-							node,
-							win.parent,
-							nodeRegion
-						);
-					}
-				}
-			}
-
-			return viewable;
 		},
 
 		/**

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -72,8 +72,6 @@ export {default as throttle} from './liferay/throttle.es';
 
 export {default as addParams} from './liferay/util/add_params';
 export {default as fetch} from './liferay/util/fetch.es';
-export {default as getDOM} from './liferay/util/get_dom';
-export {default as getElement} from './liferay/util/get_element';
 export {default as getPortletId} from './liferay/util/get_portlet_id';
 export {default as focusFormField} from './liferay/util/focus_form_field';
 export {default as inBrowserView} from './liferay/util/in_browser_view';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -72,7 +72,11 @@ export {default as throttle} from './liferay/throttle.es';
 
 export {default as addParams} from './liferay/util/add_params';
 export {default as fetch} from './liferay/util/fetch.es';
+export {default as getDOM} from './liferay/util/get_dom';
+export {default as getElement} from './liferay/util/get_element';
 export {default as getPortletId} from './liferay/util/get_portlet_id';
+export {default as focusFormField} from './liferay/util/focus_form_field';
+export {default as inBrowserView} from './liferay/util/in_browser_view';
 export {default as isPhone} from './liferay/util/is_phone';
 export {default as isTablet} from './liferay/util/is_tablet';
 export {default as navigate} from './liferay/util/navigate.es';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.es.js
@@ -72,8 +72,8 @@ export {default as throttle} from './liferay/throttle.es';
 
 export {default as addParams} from './liferay/util/add_params';
 export {default as fetch} from './liferay/util/fetch.es';
-export {default as getPortletId} from './liferay/util/get_portlet_id';
 export {default as focusFormField} from './liferay/util/focus_form_field';
+export {default as getPortletId} from './liferay/util/get_portlet_id';
 export {default as inBrowserView} from './liferay/util/in_browser_view';
 export {default as isPhone} from './liferay/util/is_phone';
 export {default as isTablet} from './liferay/util/is_tablet';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -132,12 +132,12 @@ Liferay.Util.formatXML = formatXML;
 Liferay.Util.getCropRegion = getCropRegion;
 
 /**
- * @deprecated As of Athanasius (7.3.x), replaced by `import {getDOM} from 'frontend-js-web'`
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
  */
 Liferay.Util.getDOM = getDOM;
 
 /**
- * @deprecated As of Athanasius (7.3.x), replaced by `import {getElement} from 'frontend-js-web'`
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
  */
 Liferay.Util.getElement = getElement;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -43,6 +43,7 @@ import addParams from './util/add_params';
 import getCountries from './util/address/get_countries.es';
 import getRegions from './util/address/get_regions.es';
 import fetch from './util/fetch.es';
+import focusFormField from './util/focus_form_field';
 import getFormElement from './util/form/get_form_element.es';
 import objectToFormData from './util/form/object_to_form_data.es';
 import postForm from './util/form/post_form.es';
@@ -50,8 +51,11 @@ import setFormValues from './util/form/set_form_values.es';
 import formatStorage from './util/format_storage.es';
 import formatXML from './util/format_xml.es';
 import getCropRegion from './util/get_crop_region.es';
+import getDOM from './util/get_dom';
+import getElement from './util/get_element';
 import getPortletId from './util/get_portlet_id';
 import getPortletNamespace from './util/get_portlet_namespace.es';
+import inBrowserView from './util/in_browser_view';
 import isPhone from './util/is_phone';
 import isTablet from './util/is_tablet';
 import navigate from './util/navigate.es';
@@ -117,9 +121,26 @@ Liferay.Util.addParams = addParams;
 
 Liferay.Util.escape = escape;
 Liferay.Util.fetch = fetch;
+
+/**
+ * @deprecated As of Athanasius (7.3.x), replaced by `import {focusFormField} from 'frontend-js-web'`
+ */
+Liferay.Util.focusFormField = focusFormField;
+
 Liferay.Util.formatStorage = formatStorage;
 Liferay.Util.formatXML = formatXML;
 Liferay.Util.getCropRegion = getCropRegion;
+
+/**
+ * @deprecated As of Athanasius (7.3.x), replaced by `import {getDOM} from 'frontend-js-web'`
+ */
+Liferay.Util.getDOM = getDOM;
+
+/**
+ * @deprecated As of Athanasius (7.3.x), replaced by `import {getElement} from 'frontend-js-web'`
+ */
+Liferay.Util.getElement = getElement;
+
 Liferay.Util.getFormElement = getFormElement;
 
 /**
@@ -129,6 +150,12 @@ Liferay.Util.getPortletId = getPortletId;
 
 Liferay.Util.getPortletNamespace = getPortletNamespace;
 Liferay.Util.groupBy = groupBy;
+
+/**
+ * @deprecated As of Athanasius (7.3.x), replaced by `import {inBrowserView} from 'frontend-js-web'`
+ */
+Liferay.Util.inBrowserView = inBrowserView;
+
 Liferay.Util.isEqual = isEqual;
 
 /**

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/focus_form_field.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/focus_form_field.js
@@ -30,19 +30,9 @@ function getDisabledParents(element) {
 }
 
 export default function focusFormField(element) {
-	let interacting = false;
-
 	element = getElement(element);
 
-	const handler = () => {
-		interacting = true;
-
-		document.body.removeEventListener('click', handler);
-	};
-
-	document.body.addEventListener('click', handler);
-
-	if (!interacting && inBrowserView(element)) {
+	if (inBrowserView(element)) {
 		const disabledParents = getDisabledParents(element);
 
 		const focusable =

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/focus_form_field.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/focus_form_field.js
@@ -16,14 +16,14 @@ import getElement from './get_element';
 import inBrowserView from './in_browser_view';
 
 function getDisabledParents(element) {
-	let result = [];
+	const result = [];
 
-	if (element.parentElement) {
+	while (element.parentElement) {
 		if (element.parentElement.getAttribute('disabled')) {
-			result = [element.parentElement];
+			result.push(element.parentElement);
 		}
 
-		result = [...result, ...getDisabledParents(element.parentElement)];
+		element = element.parentElement;
 	}
 
 	return result;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/focus_form_field.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/focus_form_field.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import getElement from './get_element';
+import inBrowserView from './in_browser_view';
+
+export default function focusFormField(el) {
+	let interacting = false;
+
+	el = getElement(el);
+
+	const handler = () => {
+		interacting = true;
+
+		document.body.removeEventListener('click', handler);
+	};
+
+	document.body.addEventListener('click', handler);
+
+	if (!interacting && inBrowserView(el)) {
+		const getDisabledParents = function (el) {
+			let result = [];
+
+			if (el.parentElement) {
+				if (el.parentElement.getAttribute('disabled')) {
+					result = [el.parentElement];
+				}
+
+				result = [...result, ...getDisabledParents(el.parentElement)];
+			}
+
+			return result;
+		};
+
+		const disabledParents = getDisabledParents(el);
+
+		const focusable =
+			!el.getAttribute('disabled') &&
+			el.offsetWidth > 0 &&
+			el.offsetHeight > 0 &&
+			!disabledParents.length;
+
+		const form = el.closest('form');
+
+		if (!form || focusable) {
+			el.focus();
+		}
+		else if (form) {
+			const portletName = form.getAttribute('data-fm-namespace');
+
+			const formReadyEventName = portletName + 'formReady';
+
+			const formReadyHandler = (event) => {
+				const elFormName = form.getAttribute('name');
+
+				const formName = event.formName;
+
+				if (elFormName === formName) {
+					el.focus();
+
+					Liferay.detach(formReadyEventName, formReadyHandler);
+				}
+			};
+
+			Liferay.on(formReadyEventName, formReadyHandler);
+		}
+	}
+}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/focus_form_field.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/focus_form_field.js
@@ -15,10 +15,10 @@
 import getElement from './get_element';
 import inBrowserView from './in_browser_view';
 
-export default function focusFormField(el) {
+export default function focusFormField(element) {
 	let interacting = false;
 
-	el = getElement(el);
+	element = getElement(element);
 
 	const handler = () => {
 		interacting = true;
@@ -28,33 +28,36 @@ export default function focusFormField(el) {
 
 	document.body.addEventListener('click', handler);
 
-	if (!interacting && inBrowserView(el)) {
-		const getDisabledParents = function (el) {
+	if (!interacting && inBrowserView(element)) {
+		const getDisabledParents = function (element) {
 			let result = [];
 
-			if (el.parentElement) {
-				if (el.parentElement.getAttribute('disabled')) {
-					result = [el.parentElement];
+			if (element.parentElement) {
+				if (element.parentElement.getAttribute('disabled')) {
+					result = [element.parentElement];
 				}
 
-				result = [...result, ...getDisabledParents(el.parentElement)];
+				result = [
+					...result,
+					...getDisabledParents(element.parentElement),
+				];
 			}
 
 			return result;
 		};
 
-		const disabledParents = getDisabledParents(el);
+		const disabledParents = getDisabledParents(element);
 
 		const focusable =
-			!el.getAttribute('disabled') &&
-			el.offsetWidth > 0 &&
-			el.offsetHeight > 0 &&
+			!element.getAttribute('disabled') &&
+			element.offsetWidth > 0 &&
+			element.offsetHeight > 0 &&
 			!disabledParents.length;
 
-		const form = el.closest('form');
+		const form = element.closest('form');
 
 		if (!form || focusable) {
-			el.focus();
+			element.focus();
 		}
 		else if (form) {
 			const portletName = form.getAttribute('data-fm-namespace');
@@ -67,7 +70,7 @@ export default function focusFormField(el) {
 				const formName = event.formName;
 
 				if (elFormName === formName) {
-					el.focus();
+					element.focus();
 
 					Liferay.detach(formReadyEventName, formReadyHandler);
 				}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/focus_form_field.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/focus_form_field.js
@@ -15,6 +15,20 @@
 import getElement from './get_element';
 import inBrowserView from './in_browser_view';
 
+function getDisabledParents(element) {
+	let result = [];
+
+	if (element.parentElement) {
+		if (element.parentElement.getAttribute('disabled')) {
+			result = [element.parentElement];
+		}
+
+		result = [...result, ...getDisabledParents(element.parentElement)];
+	}
+
+	return result;
+}
+
 export default function focusFormField(element) {
 	let interacting = false;
 
@@ -29,23 +43,6 @@ export default function focusFormField(element) {
 	document.body.addEventListener('click', handler);
 
 	if (!interacting && inBrowserView(element)) {
-		const getDisabledParents = function (element) {
-			let result = [];
-
-			if (element.parentElement) {
-				if (element.parentElement.getAttribute('disabled')) {
-					result = [element.parentElement];
-				}
-
-				result = [
-					...result,
-					...getDisabledParents(element.parentElement),
-				];
-			}
-
-			return result;
-		};
-
 		const disabledParents = getDisabledParents(element);
 
 		const focusable =

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_dom.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_dom.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function getDOM(el) {
+	if (el._node || el._nodes) {
+		return el.nodeType ? el : el._node || null;
+	}
+
+	return el;
+}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_dom.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_dom.js
@@ -12,6 +12,9 @@
  * details.
  */
 
+/**
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ */
 export default function getDOM(element) {
 	if (element._node || element._nodes) {
 		return element.nodeType ? element : element._node || null;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_dom.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_dom.js
@@ -12,10 +12,10 @@
  * details.
  */
 
-export default function getDOM(el) {
-	if (el._node || el._nodes) {
-		return el.nodeType ? el : el._node || null;
+export default function getDOM(element) {
+	if (element._node || element._nodes) {
+		return element.nodeType ? element : element._node || null;
 	}
 
-	return el;
+	return element;
 }

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_element.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_element.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import getDOM from './get_dom';
+
+export default function getElement(el) {
+	const currentElement = getDOM(el);
+
+	return typeof currentElement === 'string'
+		? document.querySelector(currentElement)
+		: currentElement.jquery
+		? currentElement[0]
+		: currentElement;
+}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_element.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_element.js
@@ -14,6 +14,9 @@
 
 import getDOM from './get_dom';
 
+/**
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ */
 export default function getElement(element) {
 	const currentElement = getDOM(element);
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_element.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/get_element.js
@@ -14,8 +14,8 @@
 
 import getDOM from './get_dom';
 
-export default function getElement(el) {
-	const currentElement = getDOM(el);
+export default function getElement(element) {
+	const currentElement = getDOM(element);
 
 	return typeof currentElement === 'string'
 		? document.querySelector(currentElement)

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/in_browser_view.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/in_browser_view.js
@@ -53,10 +53,10 @@ export default function inBrowserView(node, baseWindow, nodeRegion) {
 			nodeRegion.top >= winRegion.top;
 
 		if (viewable) {
-			const frameEl = baseWindow.frameElement;
+			const frameElement = baseWindow.frameElement;
 
-			if (frameEl) {
-				let frameOffset = frameEl.getBoundingClientRect();
+			if (frameElement) {
+				let frameOffset = frameElement.getBoundingClientRect();
 
 				frameOffset = {
 					left: frameOffset.left + window.scrollX,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/in_browser_view.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/in_browser_view.js
@@ -63,12 +63,12 @@ export default function inBrowserView(node, win, nodeRegion) {
 					top: frameOffset.top + window.scrollY,
 				};
 
-				var xOffset = frameOffset.left - winRegion.left;
+				const xOffset = frameOffset.left - winRegion.left;
 
 				nodeRegion.left += xOffset;
 				nodeRegion.right += xOffset;
 
-				var yOffset = frameOffset.top - winRegion.top;
+				const yOffset = frameOffset.top - winRegion.top;
 
 				nodeRegion.top += yOffset;
 				nodeRegion.bottom += yOffset;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/in_browser_view.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/in_browser_view.js
@@ -14,7 +14,7 @@
 
 import getElement from './get_element';
 
-export default function inBrowserView(node, win, nodeRegion) {
+export default function inBrowserView(node, baseWindow, nodeRegion) {
 	let viewable = false;
 
 	node = getElement(node);
@@ -32,19 +32,19 @@ export default function inBrowserView(node, win, nodeRegion) {
 			nodeRegion.right = nodeRegion.left + node.offsetWidth;
 		}
 
-		if (!win) {
-			win = window;
+		if (!baseWindow) {
+			baseWindow = window;
 		}
 
-		win = getElement(win);
+		baseWindow = getElement(baseWindow);
 
 		const winRegion = {};
 
-		winRegion.left = win.scrollX;
-		winRegion.right = winRegion.left + win.innerWidth;
+		winRegion.left = baseWindow.scrollX;
+		winRegion.right = winRegion.left + baseWindow.innerWidth;
 
-		winRegion.top = win.scrollY;
-		winRegion.bottom = winRegion.top + win.innerHeight;
+		winRegion.top = baseWindow.scrollY;
+		winRegion.bottom = winRegion.top + baseWindow.innerHeight;
 
 		viewable =
 			nodeRegion.bottom <= winRegion.bottom &&
@@ -53,7 +53,7 @@ export default function inBrowserView(node, win, nodeRegion) {
 			nodeRegion.top >= winRegion.top;
 
 		if (viewable) {
-			const frameEl = win.frameElement;
+			const frameEl = baseWindow.frameElement;
 
 			if (frameEl) {
 				let frameOffset = frameEl.getBoundingClientRect();
@@ -73,7 +73,7 @@ export default function inBrowserView(node, win, nodeRegion) {
 				nodeRegion.top += yOffset;
 				nodeRegion.bottom += yOffset;
 
-				viewable = inBrowserView(node, win.parent, nodeRegion);
+				viewable = inBrowserView(node, baseWindow.parent, nodeRegion);
 			}
 		}
 	}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/in_browser_view.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/in_browser_view.js
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import getElement from './get_element';
+
+export default function inBrowserView(node, win, nodeRegion) {
+	let viewable = false;
+
+	node = getElement(node);
+
+	if (node) {
+		if (!nodeRegion) {
+			nodeRegion = node.getBoundingClientRect();
+
+			nodeRegion = {
+				left: nodeRegion.left + window.scrollX,
+				top: nodeRegion.top + window.scrollY,
+			};
+
+			nodeRegion.bottom = nodeRegion.top + node.offsetHeight;
+			nodeRegion.right = nodeRegion.left + node.offsetWidth;
+		}
+
+		if (!win) {
+			win = window;
+		}
+
+		win = getElement(win);
+
+		const winRegion = {};
+
+		winRegion.left = win.scrollX;
+		winRegion.right = winRegion.left + win.innerWidth;
+
+		winRegion.top = win.scrollY;
+		winRegion.bottom = winRegion.top + win.innerHeight;
+
+		viewable =
+			nodeRegion.bottom <= winRegion.bottom &&
+			nodeRegion.left >= winRegion.left &&
+			nodeRegion.right <= winRegion.right &&
+			nodeRegion.top >= winRegion.top;
+
+		if (viewable) {
+			const frameEl = win.frameElement;
+
+			if (frameEl) {
+				let frameOffset = frameEl.getBoundingClientRect();
+
+				frameOffset = {
+					left: frameOffset.left + window.scrollX,
+					top: frameOffset.top + window.scrollY,
+				};
+
+				var xOffset = frameOffset.left - winRegion.left;
+
+				nodeRegion.left += xOffset;
+				nodeRegion.right += xOffset;
+
+				var yOffset = frameOffset.top - winRegion.top;
+
+				nodeRegion.top += yOffset;
+				nodeRegion.bottom += yOffset;
+
+				viewable = inBrowserView(node, win.parent, nodeRegion);
+			}
+		}
+	}
+
+	return viewable;
+}


### PR DESCRIPTION
The goal of this change is to deprecate the `Liferay.Util.focusFormField`
function: it will now be available as a module (i.e. it can be `import`ed),
as well as a global to avoid breaking changes.

This function was also using the following functions:
- `getDOM`
- `getElement`
- `inBrowserView`
that have also been moved to the `frontend-js-web` module.

An easy way to test this, after having fetched these changes, it to
deploy the `frontend-js-aui-web` and `frontend-js-web` modules, and to
sign into liferay-portal (or sign out  and sign in, if already signed
in).