### PR TITLE
LPS-112494 Add t=Date.now parameter to the url

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/logo_selector.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/logo_selector.js
@@ -76,6 +76,8 @@ AUI.add(
 				_changeLogo(url, fileEntryId) {
 					var instance = this;
 
+					url = Liferay.Util.addParams('t=' + Date.now(), url);
+
 					instance.set('logoURL', url);
 
 					if (fileEntryId) {


### PR DESCRIPTION
Hi @wincent ,

Can you review this pull request?

In [LPS-112494](https://issues.liferay.com/browse/LPS-112494) you can see the steps to reproduce this behavior.

The root cause of the issue is that we are building the logo URL based only on the file's title. So if we upload the same file twice, although the second time we are cropping the image (so we are creating a new logo), it won't be updated.

Thanks.

Regards.

/cc @rolandpakai