### PR TITLE
LPS-111979 Center CKEditor dialogs

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/extension/dialog_definition.js
@@ -23,30 +23,28 @@ CKEDITOR.on('dialogDefinition', (event) => {
 				onShow.apply(this, arguments);
 			}
 
-			if (window.top != window.self) {
-				var editorElement = this.getParentEditor().container;
+			var editorElement = this.getParentEditor().container;
 
-				var documentPosition = editorElement
-					.getLast()
-					.getDocumentPosition();
+			var documentPosition = editorElement
+				.getLast()
+				.getDocumentPosition();
 
-				var dialogSize = this.getSize();
+			var dialogSize = this.getSize();
 
-				var x =
-					documentPosition.x +
-					((editorElement.getLast().getSize('width', true) -
-						dialogSize.width) /
-						2 -
-						window.scrollX);
-				var y =
-					documentPosition.y +
-					((editorElement.getLast().getSize('height', true) -
-						dialogSize.height) /
-						2 -
-						window.scrollY);
+			var x =
+				documentPosition.x +
+				((editorElement.getLast().getSize('width', true) -
+					dialogSize.width) /
+					2 -
+					window.scrollX);
+			var y =
+				documentPosition.y +
+				((editorElement.getLast().getSize('height', true) -
+					dialogSize.height) /
+					2 -
+					window.scrollY);
 
-				this.move(x, y, false);
-			}
+			this.move(x, y, false);
 		};
 	}
 });


### PR DESCRIPTION
The goal of this fix is to "center" CKEditor's dialogs.

Since our recent change to use CKEditor in more places, CKEditor dialogs
are now aligned in the top left corner instead of being centered.

The only previous commit I could find concerning this file is in
[https://github.com/liferay/liferay-portal/commit/a4df2c65a8fb39c139e0e9781078b2092c868f68](https://github.com/liferay/liferay-portal/commit/a4df2c65a8fb39c139e0e9781078b2092c868f68),
when the file was initially added.