### PR TITLE
LPS-113231 Audit lints and suppressions related to arrow functions for IE

### DIFF
--- a/modules/apps/frontend-compatibility/frontend-compatibility-ie/.eslintrc.js
+++ b/modules/apps/frontend-compatibility/frontend-compatibility-ie/.eslintrc.js
@@ -14,6 +14,7 @@
 
 module.exports = {
 	rules: {
+		'liferay/no-arrow': 'error',
 		'prefer-arrow-callback': 'off',
 	},
 };

--- a/modules/apps/frontend-theme/frontend-theme-classic/src/js/main.js
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/js/main.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-/* eslint-disable prefer-arrow-callback */
 (function () {
 	var signInLink = document.querySelector('.sign-in > a');
 

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/.eslintrc.js
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/.eslintrc.js
@@ -14,6 +14,7 @@
 
 module.exports = {
 	rules: {
+		'liferay/no-arrow': 'error',
 		'prefer-arrow-callback': 'off',
 	},
 };


### PR DESCRIPTION
Follow-up to [LPS-113193](https://issues.liferay.com/browse/LPS-113193) (https://github.com/brianchandotcom/liferay-portal/pull/88445).

We added a lint rule to stop arrow functions from sneaking into untranspiled JS that gets served to IE. This commit is result of auditing codebase to see if there are any places where we should be applying the rule but aren't doing so yet (found 2), and to remove any related suppressions that are no longer required since adding the rule (found 1; don't need it inline in frontend-theme-classic because it is being applied to the entire module already via an .eslintrc.js file).