### PR TITLE
LPS-112942 Migrate Liferay.Poller from AUI

### DIFF
--- a/modules/apps/archived/chat-web/build.gradle
+++ b/modules/apps/archived/chat-web/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:archived:chat-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-taglib")
+	compileOnly project(":apps:petra:petra-encryptor")
 	compileOnly project(":apps:portal:portal-upgrade-api")
 	compileOnly project(":apps:static:portal:portal-profile-api")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/archived/chat-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/archived/chat-web/src/main/resources/META-INF/resources/init.jsp
@@ -25,6 +25,7 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 page import="com.liferay.chat.service.StatusLocalServiceUtil" %><%@
 page import="com.liferay.chat.web.internal.util.BuddyFinderUtil" %><%@
 page import="com.liferay.chat.web.internal.util.ChatExtensionsUtil" %><%@
+page import="com.liferay.petra.encryptor.Encryptor" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.json.JSONFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.json.JSONObject" %><%@

--- a/modules/apps/archived/chat-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/archived/chat-web/src/main/resources/META-INF/resources/view.jsp
@@ -27,6 +27,15 @@
 	</liferay-util:html-top>
 
 	<liferay-util:html-bottom>
+		<aui:script use="liferay-poller">
+			<c:if test="<%= themeDisplay.isSignedIn() %>">
+				Liferay.Poller.init({
+					encryptedUserId:
+						'<%= Encryptor.encrypt(company.getKeyObj(), String.valueOf(themeDisplay.getUserId())) %>',
+				});
+			</c:if>
+		</aui:script>
+
 		<script data-senna-track="temporary" defer="defer" src="<%= PortalUtil.getStaticResourceURL(request, themeDisplay.getCDNHost() + PortalUtil.getPathContext(request) + "/js/main.js", portlet.getTimestamp()) %>" type="text/javascript"></script>
 	</liferay-util:html-bottom>
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/poller.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/poller.js
@@ -12,6 +12,9 @@
  * details.
  */
 
+/**
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ */
 AUI.add(
 	'liferay-poller',
 	(A) => {

--- a/portal-web/docroot/html/common/init.jsp
+++ b/portal-web/docroot/html/common/init.jsp
@@ -36,7 +36,6 @@ page import="com.liferay.asset.kernel.service.AssetTagServiceUtil" %><%@
 page import="com.liferay.document.library.kernel.model.DLFileEntry" %><%@
 page import="com.liferay.exportimport.kernel.staging.LayoutStagingUtil" %><%@
 page import="com.liferay.exportimport.kernel.staging.StagingUtil" %><%@
-page import="com.liferay.petra.encryptor.Encryptor" %><%@
 page import="com.liferay.petra.string.CharPool" %><%@
 page import="com.liferay.petra.string.StringBundler" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@

--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -190,7 +190,7 @@ if (layout != null) {
 	</aui:script>
 </c:if>
 
-<aui:script use="liferay-menu,liferay-notice,liferay-poller">
+<aui:script use="liferay-menu,liferay-notice">
 	new Liferay.Menu();
 
 	var liferayNotices = Liferay.Data.notices;
@@ -199,14 +199,6 @@ if (layout != null) {
 		new Liferay.Notice(liferayNotices[i]);
 	}
 
-	<c:if test="<%= themeDisplay.isSignedIn() %>">
-		Liferay.Poller.init(
-			{
-				encryptedUserId: '<%= Encryptor.encrypt(company.getKeyObj(), String.valueOf(themeDisplay.getUserId())) %>',
-				supportsComet: <%= ServerDetector.isSupportsComet() %>
-			}
-		);
-	</c:if>
 </aui:script>
 
 <script type="text/javascript">

--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -582,29 +582,39 @@ vocabulary in all languages.
 
 #### What changed?
 
-The global AUI `Liferay.Poller` utility is now deprecated and is no longer initialized by default.
+The global AUI `Liferay.Poller` utility is now deprecated and is no longer
+initialized by default.
 
 #### Who is affected?
 
 This affects any code that relies on `Liferay.Poller`; this is
-usually done via `jsp` with `Liferay.Poller.init`.
+usually done via a call to `Liferay.Poller.init()` in a JSP.
 
 #### How should I update my code?
 
-There's no direct replacement for the Liferay.Poller utility.
-If you need to initialize Liferay.Poller, include the snippet below:
+There's no direct replacement for the `Liferay.Poller` utility.  If you
+need to initialize `Liferay.Poller`, do the following:
+
 ```
+<%@ page import="com.liferay.petra.encryptor.Encryptor" %>
+
+<%-- For access to `company` and `themeDisplay`. --%>
+<liferay-theme:defineObjects>
+
 <aui:script use="liferay-poller">
-	Liferay.Poller.init({
-		encryptedUserId
-	});
+	<c:if test="<%= themeDisplay.isSignedIn() %>">
+		Liferay.Poller.init({
+			encryptedUserId:
+				'<%= Encryptor.encrypt(company.getKeyObj(), String.valueOf(themeDisplay.getUserId())) %>',
+		});
+	</c:if>
 </aui:script>
-    
 ```
 
 #### Why was this change made?
 
-The Liferay.Poller component was only used in the Chat application, which is archived, so it was
-deprecated in 7.3 and is no longer initialized by default.
+The `Liferay.Poller` component was only used in the Chat application, which is
+archived. Skipping initialization by default streamlines page loads for the
+common case.
 
 ---------------------------------------

--- a/readme/BREAKING_CHANGES.markdown
+++ b/readme/BREAKING_CHANGES.markdown
@@ -575,3 +575,36 @@ The change was made so users don't have to change the name for the default
 vocabulary in all languages.
 
 ---------------------------------------
+
+### Liferay.Poller Is No Longer Initialized by Default
+- **Date:** 2020-May-19
+- **JIRA Ticket:** [LPS-112942](https://issues.liferay.com/browse/LPS-112942)
+
+#### What changed?
+
+The global AUI `Liferay.Poller` utility is now deprecated and is no longer initialized by default.
+
+#### Who is affected?
+
+This affects any code that relies on `Liferay.Poller`; this is
+usually done via `jsp` with `Liferay.Poller.init`.
+
+#### How should I update my code?
+
+There's no direct replacement for the Liferay.Poller utility.
+If you need to initialize Liferay.Poller, include the snippet below:
+```
+<aui:script use="liferay-poller">
+	Liferay.Poller.init({
+		encryptedUserId
+	});
+</aui:script>
+    
+```
+
+#### Why was this change made?
+
+The Liferay.Poller component was only used in the Chat application, which is archived, so it was
+deprecated in 7.3 and is no longer initialized by default.
+
+---------------------------------------


### PR DESCRIPTION
In this PR `liferay-poller` AUI api is moved from `frontend-aui-web` and modernized in VanillaJS, moving its functionality in `frontend-js-web` module with replicated behaviour.

The global of this util `Liferay.Poller` is now marked as deprecated because we don’t want to encourage usage of globals. Additionally, the old util is marked as deprecated in `frontend-js-aui-web`. 

This utility has exactly 1 usage in the portal in `portal-web`, which can be deployed by running `ant deploy`.