### PR TITLE
LPS-113411 Modals with iframe but no footer have unnecessary bottom padding

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_dialog.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/application/_dialog.scss
@@ -136,42 +136,31 @@
 	.portlet-export-import-publish-processes {
 		top: 0;
 	}
-}
 
-.dialog-with-footer {
-	#main-content,
-	#wrapper {
-		@include media-breakpoint-up(md) {
-			height: calc(100% - #{$dialog-footer-height});
+	.dialog-footer {
+		background-color: $dialog-footer-bg;
+		border-top: 1px solid $dialog-footer-border-color;
+		bottom: 0;
+
+		@if (variable-exists(dialog-footer-box-shadow)) {
+			box-shadow: $dialog-footer-box-shadow;
 		}
-	}
 
-	.button-holder,
-	.sheet-footer {
-		&.dialog-footer {
-			background-color: $dialog-footer-bg;
-			border-top: 1px solid $dialog-footer-border-color;
-			bottom: 0;
+		display: flex;
+		flex-direction: row-reverse;
+		left: 0;
+		margin: 0;
+		padding: 10px 24px;
+		width: 100%;
+		z-index: $zindex-sticky;
 
-			@if (variable-exists(dialog-footer-box-shadow)) {
-				box-shadow: $dialog-footer-box-shadow;
-			}
+		@include media-breakpoint-up(md) {
+			position: fixed;
+		}
 
-			display: flex;
-			flex-direction: row-reverse;
-			left: 0;
-			margin: 0;
-			padding: 10px 24px;
-			width: 100%;
-
-			@include media-breakpoint-up(md) {
-				position: fixed;
-			}
-
-			.btn {
-				margin-left: 1rem;
-				margin-right: 0;
-			}
+		.btn {
+			margin-left: 1rem;
+			margin-right: 0;
 		}
 	}
 
@@ -181,7 +170,9 @@
 	.portlet-configuration-body-content,
 	.roles-selector-body {
 		@include media-breakpoint-up(md) {
-			padding-bottom: $dialog-footer-height;
+			&:not(:last-child) {
+				padding-bottom: $dialog-footer-height;
+			}
 		}
 	}
 

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_pop_up.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_pop_up.ftl
@@ -10,7 +10,7 @@
 	<@liferay_util["include"] page=top_head_include />
 </head>
 
-<body class="dialog-iframe-popup dialog-with-footer portal-popup ${css_class}">
+<body class="dialog-iframe-popup portal-popup ${css_class}">
 
 <@liferay_util["include"] page=content_include />
 


### PR DESCRIPTION
Hey @wincent ,

This is a followup on https://github.com/wincent/liferay-portal/pull/261

I reverted some unnecessary changes on fixed header, the footer styles commit is the same.

I left in the awkward 1271px width. I just cannot explain why 1280px is bigger in header row. Computed width in dev tools shows the same size. Maybe @marcoscv-work can help here. With the 1271px width, the appearance is pixel-perfect on Chrome, but 1-2 px off on Firefox.

The width change should not be a blocker to push PR. The change is limited in scope and still better than current full width size. Alternative solution would be to revert table width to 100% like it used to be, but that can be considered and maybe done in a separate task.

The changes on dialog-footer are riskier, we might want to wait for extra review on those.

Please review the code.

Thank you!

/cc @jbalsas