### PR TITLE
LPS-112983 Remove the `.js` prefix in stylesheets

### DIFF
--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_panel_component.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_panel_component.scss
@@ -89,15 +89,13 @@
 	border-top: 1px solid transparent;
 }
 
-.js {
-	.lfr-floating-container {
-		position: absolute;
-	}
+.lfr-floating-container {
+	position: absolute;
+}
 
-	.lfr-floating-trigger {
-		padding: 3px;
-		padding-right: 15px;
-	}
+.lfr-floating-trigger {
+	padding: 3px;
+	padding-right: 15px;
 }
 
 .lfr-floating-container {

--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_panel_component.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_panel_component.scss
@@ -89,16 +89,14 @@
 	border-top: 1px solid transparent;
 }
 
-.lfr-floating-container {
-	position: absolute;
-}
-
 .lfr-floating-trigger {
 	padding: 3px;
 	padding-right: 15px;
 }
 
 .lfr-floating-container {
+	position: absolute;
+
 	.col {
 		float: left;
 		margin-right: 10px;

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_webdav.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_webdav.scss
@@ -1,4 +1,4 @@
-.js .taglib-webdav {
+.taglib-webdav {
 	&.visible {
 		background: #f0f5f7;
 	}


### PR DESCRIPTION
The original discussion was started in #249, and more specifically [here](https://github.com/wincent/liferay-portal/pull/249#issuecomment-624717901)

The `js` CSS class is added by `Liferay.BrowserSelectors` [here](https://github.com/liferay/liferay-portal/blob/17bf6add3fcda2c46093a32d61442c9e97669bfa/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/browser_selectors.js#L237) and was used in  a couple of places, some usages were in `test/` directories and those usages haven't been updated because it didn't seem necessary - see this [comment](https://github.com/wincent/liferay-portal/pull/249#issuecomment-624734400)