### PR TITLE
LPS-112983 Remove `.firefox` prefix from stylesheets

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/common_main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/common_main.scss
@@ -106,7 +106,3 @@
 		}
 	}
 }
-
-.firefox .portlet-blogs fieldset {
-	display: table-cell;
-}

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/css/main.scss
@@ -339,10 +339,6 @@
 	}
 }
 
-.firefox .portlet-blogs fieldset.input-container {
-	display: table-column;
-}
-
 .social-boomarks-options {
 	margin-left: 2em;
 }

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/css/main.scss
@@ -719,16 +719,3 @@ $productMenuWidth: 320px;
 .autocomplete-dropdown-menu {
 	z-index: 2000;
 }
-
-.firefox {
-	.portlet-document-library,
-	.portlet-document-library-display {
-		.audio-node {
-			height: 28px;
-		}
-
-		.common-file-metadata-container fieldset {
-			display: table-cell;
-		}
-	}
-}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/css/main.scss
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/image_gallery_display/css/main.scss
@@ -97,11 +97,3 @@
 		@include text-truncate();
 	}
 }
-
-.firefox {
-	.portlet-image-gallery-display {
-		.audio-node {
-			height: 35px;
-		}
-	}
-}

--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_preview.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portal/_preview.scss
@@ -68,7 +68,3 @@
 	background: url(../images/common/checkerboard.png);
 	border-color: #555;
 }
-
-.firefox .lfr-preview-video-content div.video-node {
-	height: 100%;
-}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/common.scss
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/css/common.scss
@@ -323,16 +323,6 @@
 	min-height: 0;
 }
 
-.firefox .knowledge-base-portlet {
-	fieldset {
-		display: table-cell;
-	}
-
-	.kbarticle-navigation a {
-		word-wrap: break-word;
-	}
-}
-
 // ---------- Skin ----------
 
 .knowledge-base-portlet {

--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/css/main.scss
@@ -25,9 +25,3 @@
 		margin-left: 20px;
 	}
 }
-
-.firefox {
-	.portlet-users-admin fieldset {
-		display: table-cell;
-	}
-}


### PR DESCRIPTION
The original PR and discussion was started [here](https://github.com/wincent/liferay-portal/pull/249)

The `.firefox` prefix had been added in various stylesheets to fix Firefox related issues

These are the LPS issues and commits that I checked in order to know, what was supposed to be fixed

- https://issues.liferay.com/browse/LPS-66438
- https://github.com/brianchandotcom/liferay-portal/pull/40690

- https://issues.liferay.com/browse/LPS-27110
- https://github.com/liferay/liferay-portal/commit/1e52a1550531bf36656cc0eb314897971f7806c0

- https://issues.liferay.com/browse/LPS-31930
- https://github.com/liferay/liferay-portal/commit/c5083e631cba03c8d904fb373d5106726db2fad5

- https://issues.liferay.com/browse/LPS-54687
- https://github.com/liferay/liferay-portal/commit/1de4fe0e1120b7f049c4f4412f85c825aa3e126c#diff-50bc22d8ec81e4d512b0928fbe4f5af1R57-R59

- https://issues.liferay.com/browse/LPS-68401
- https://github.com/liferay/liferay-portal/commit/57ff027624a0a31a541323fa1cba3cf34852f69c (Surprisingly this one can still be reproduced in master)

- https://issues.liferay.com/browse/LPS-42356
- https://github.com/liferay/liferay-portal/commit/10c7d690312ce1ce2ee3b3228ab9aebde3142c2f