### PR TITLE
LPS-112983 Remove dependence on `.mac` prefix from BrowserSelectors

### DIFF
--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_accessibility.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_accessibility.scss
@@ -49,10 +49,8 @@ td.stretch {
 					padding: 3px;
 				}
 
-				&.mac {
-					&:after {
-						content: 'Option+0';
-					}
+				&.mac:after {
+					content: 'Option+0';
 				}
 			}
 		}

--- a/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_accessibility.scss
+++ b/modules/apps/frontend-css/frontend-css-web/src/main/resources/META-INF/resources/portal/_accessibility.scss
@@ -48,15 +48,13 @@ td.stretch {
 					margin-left: 5px;
 					padding: 3px;
 				}
+
+				&.mac {
+					&:after {
+						content: 'Option+0';
+					}
+				}
 			}
 		}
-	}
-}
-
-.mac {
-	.cke_toolbar.cke_toolbar__a11yhelpbtn
-		.cke_button
-		.cke_button__a11ybtn_label:after {
-		content: 'Option+0';
 	}
 }

--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/a11yhelpbtn/plugin.js
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/resources/META-INF/resources/_diffs/plugins/a11yhelpbtn/plugin.js
@@ -42,6 +42,15 @@
 							'class="cke_toolbar cke_toolbar_last cke_toolbar__a11yhelpbtn"'
 						);
 
+					if (CKEDITOR.env.mac) {
+						toolbarText = toolbarText
+							.replace(/\bAlt\+0\b/g, 'Option+0')
+							.replace(
+								'class="cke_button_label cke_button__a11ybtn_label"',
+								'class="cke_button_label cke_button__a11ybtn_label mac"'
+							);
+					}
+
 					event.data.html =
 						toolbarHTML.substr(0, a11ToolbarIndex) + toolbarText;
 				}


### PR DESCRIPTION
The original PR and discussion was started [here](https://github.com/wincent/liferay-portal/pull/249)

In this PR we're removing the `mac` prefix from the only place it was used, but this might be a little bit more tricky - So we might want to re-discuss this case.

As far as I understand, the `.mac` prefix let us change the "help text"  that is shown for CKEditor's `ay11help` plugin that was added in https://github.com/liferay/liferay-portal/commit/12aac234c7c66a70900665b98dce9279b3de05fa