### PR TITLE
LPS-113636 The Setup Wizard page is displayed incorrectly

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -286,12 +286,13 @@ class Iframe extends React.Component {
 
 		const namespace = iframeURL.searchParams.get('p_p_id');
 
+		let bodyCssClass = 'dialog-iframe-popup';
+
 		if (props.iframeBodyCssClass) {
-			iframeURL.searchParams.set(
-				`_${namespace}_bodyCssClass`,
-				props.iframeBodyCssClass
-			);
+			bodyCssClass = `${bodyCssClass} ${props.iframeBodyCssClass}`;
 		}
+
+		iframeURL.searchParams.set(`_${namespace}_bodyCssClass`, bodyCssClass);
 
 		this.state = {loading: true, src: iframeURL.toString()};
 	}
@@ -312,9 +313,17 @@ class Iframe extends React.Component {
 			() => this.props.processClose()
 		);
 
+		iframe.contentWindow.document.body.classList.add('dialog-iframe-popup');
+
 		this.props.updateLoading(false);
 
 		this.setState({loading: false});
+
+		iframe.contentWindow.onunload = () => {
+			this.props.updateLoading(true);
+
+			this.setState({loading: true});
+		};
 
 		Liferay.fire('modalIframeLoaded', {src: this.state.src});
 	};

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/modal/__snapshots__/Modal.js.snap
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/modal/__snapshots__/Modal.js.snap
@@ -56,8 +56,8 @@ exports[`Modal renders markup based on given configuration 1`] = `
               />
               <iframe
                 class="hide"
-                src="https://www.sample.url/?p_p_id=com_liferay_MyPortlet"
-                title="https://www.sample.url/?p_p_id=com_liferay_MyPortlet"
+                src="https://www.sample.url/?p_p_id=com_liferay_MyPortlet&_com_liferay_MyPortlet_bodyCssClass=dialog-iframe-popup"
+                title="https://www.sample.url/?p_p_id=com_liferay_MyPortlet&_com_liferay_MyPortlet_bodyCssClass=dialog-iframe-popup"
               />
             </div>
           </div>

--- a/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_pop_up.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-unstyled/src/main/resources/META-INF/resources/_unstyled/templates/portal_pop_up.ftl
@@ -10,7 +10,7 @@
 	<@liferay_util["include"] page=top_head_include />
 </head>
 
-<body class="dialog-iframe-popup portal-popup ${css_class}">
+<body class="portal-popup ${css_class}">
 
 <@liferay_util["include"] page=content_include />
 

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -99,6 +99,6 @@ String redirect = ParamUtil.getString(request, "redirect");
 			uri
 		);
 
-		location.href = uri;
+		Liferay.Util.navigate(uri);
 	}
 </aui:script>


### PR DESCRIPTION
Hey @wincent ,

This is a followup on https://github.com/marcoscv-work/liferay-portal/pull/320, an alternative solution.

We are reverting addition of iframe class in theme template. This will fix the issue of the ticket, as well as styles on any other page that used modal template outside modal.

After revert, we again have the issue that modal navigation sometimes does not set iframe body classes. What I discovered today is we do not have this issue if use SPA-enabling `Liferay.Util.navigate` util. So, [the changes in onLoadHandler](https://github.com/wincent/liferay-portal/commit/da4b8eada9cf84ec32a38f67f028139cb1f8e031#diff-45c988fca3398d3143e41f2f53e309a7R316-R327) are not needed if we [make this change](https://github.com/wincent/liferay-portal/commit/a7f32fcde8e858cdf981847f45f5a7d084e8ef95). However, there are two problems with this:
1. There are probably other usages where we directly set url and open it in modal. I didn't find any, it seems that most open top window url, but they do likely exist.
1. People can turn off SPA.

So, we are providing a solution for raw url change, but in it there is still a small issue. To reproduce:
- Revert [this line](https://github.com/wincent/liferay-portal/commit/a7f32fcde8e858cdf981847f45f5a7d084e8ef95). The issue is fixed in that line, but it will exist on the same type of usage.
- Open configuration of Web Content Display app.
- Browse tabs. Note - footer looks the same.
- Select a web content, choose one.
- Note - footer looks the same. The class this time was set on onload event. We have a spinner so there is no glitching.
- Browse tabs. Note - footer styles break, the class on body is not set.

I think we can move forward with this, as the existing issue is a minor one, specially compared to the one in the ticket. The issue will eventually be completely fixed, as a part of usages update.

Please review the code.

Thank you!

/cc @jbalsas @marcoscv-work