### PR TITLE
LPS-113848 Branches URL creation to avoid passing undefined as the base param

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/add_params.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/add_params.js
@@ -28,10 +28,20 @@ export default function addParams(params, baseUrl) {
 		throw new TypeError('Parameter baseUrl must be a string');
 	}
 
-	const url = new URL(
-		baseUrl,
-		baseUrl.startsWith('/') ? location.href : undefined
-	);
+	// LPS-113848
+
+	// Branches the URL initialization. Safari 13.1 will throw a TypeError error
+	// when calling the `new URL(url, base)` constructor with `undefined` as the
+	// `base` parameter
+
+	let url;
+
+	if (baseUrl.startsWith('/')) {
+		url = new URL(baseUrl, location.href);
+	}
+	else {
+		url = new URL(baseUrl);
+	}
 
 	if (typeof params === 'object') {
 		Object.entries(params).forEach(([key, value]) => {


### PR DESCRIPTION
Not sure what else to say about this... fix for the `new URL(base, undefined)` problem in Safari 13.1.

This branches the URL creation... roughly tested and edited, so feel free to do this properly :D