### PR TITLE
LPS-113848 Branches URL creation to avoid passing undefined as the base param

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/add_params.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/add_params.js
@@ -28,20 +28,9 @@ export default function addParams(params, baseUrl) {
 		throw new TypeError('Parameter baseUrl must be a string');
 	}
 
-	// LPS-113848
-
-	// Branches the URL initialization. Safari 13.1 will throw a TypeError error
-	// when calling the `new URL(url, base)` constructor with `undefined` as the
-	// `base` parameter
-
-	let url;
-
-	if (baseUrl.startsWith('/')) {
-		url = new URL(baseUrl, location.href);
-	}
-	else {
-		url = new URL(baseUrl);
-	}
+	const url = baseUrl.startsWith('/')
+		? new URL(baseUrl, location.href)
+		: new URL(baseUrl);
 
 	if (typeof params === 'object') {
 		Object.entries(params).forEach(([key, value]) => {

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/add_params.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/add_params.js
@@ -28,10 +28,20 @@ export default function addParams(params, baseUrl) {
 		throw new TypeError('Parameter baseUrl must be a string');
 	}
 
-	const url = new URL(
-		baseUrl,
-		baseUrl.startsWith('/') ? location.href : undefined
-	);
+	// LPS-113848
+
+	// Branches the URL initialization. Safari 13.1 will throw a TypeError error
+	// when calling the `new URL(url, base)` constructor with `undefined` as the
+	// `base` parameter
+
+	let url;
+
+	if (baseUrl.startsWith('/')) {
+		url = new URL(baseUrl, location.href);
+	}
+	else {
+		url = new URL(baseUrl);
+	}
 
 	if (typeof params === 'object') {
 		Object.entries(params).forEach(([key, value]) => {


### PR DESCRIPTION
Based on experimentation, `new URL(url, undefined)` throws a TypeError error in latest Safari Version 13.1 (13609.1.20.111.8). As a result, we avoid calling the constructur with 2 parameters when the second is not set as a string.

Previously: https://github.com/wincent/liferay-portal/pull/278

cc @jbalsas @jpince