### PR TITLE
LPS-112897 Update modal usages in journal

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -180,7 +180,15 @@ const Modal = ({
 		let eventHandler;
 
 		if (onSelect && selectEventName) {
-			eventHandler = Liferay.on(selectEventName, onSelect);
+			eventHandler = Liferay.on(selectEventName, (selectedItem) => {
+				onSelect(selectedItem);
+
+				setVisible(false);
+
+				if (onClose) {
+					onClose();
+				}
+			});
 		}
 
 		return () => {
@@ -188,7 +196,7 @@ const Modal = ({
 				eventHandler.detach();
 			}
 		};
-	}, [onSelect, selectEventName]);
+	}, [onClose, onSelect, selectEventName]);
 
 	return (
 		<>

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -305,6 +305,12 @@ class Iframe extends React.Component {
 		this.state = {loading: true, src: iframeURL.toString()};
 	}
 
+	componentDidUpdate(prevProps, prevState) {
+		if (!this.state.loading && prevState.loading) {
+			Liferay.fire('modalIframeLoaded', {src: this.state.src});
+		}
+	}
+
 	componentWillUnmount() {
 		if (this.delegateHandler) {
 			this.delegateHandler.removeListener();
@@ -332,8 +338,6 @@ class Iframe extends React.Component {
 
 			this.setState({loading: true});
 		};
-
-		Liferay.fire('modalIframeLoaded', {src: this.state.src});
 	};
 
 	render() {

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/journal_template.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/journal_template.jsp
@@ -104,22 +104,12 @@ AssetRenderer<JournalArticle> assetRenderer = assetRendererFactory.getAssetRende
 				alert.destroy();
 			}
 
-			Liferay.Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						destroyOnHide: true,
-						modal: true,
-					},
-					eventName:
-						'<%= PortalUtil.getPortletNamespace(portletId) + "selectDDMTemplate" %>',
-					id:
-						'<%= PortalUtil.getPortletNamespace(portletId) + "selectDDMTemplate" %>',
-					title: '<liferay-ui:message key="templates" />',
-					uri: '<%= selectDDMTemplateURL %>',
-				},
-				function (event) {
-					templateKeyInput.setAttribute('value', event.ddmtemplatekey);
+			Liferay.Util.openModal({
+				onSelect: function (selectedItem) {
+					templateKeyInput.setAttribute(
+						'value',
+						selectedItem.ddmtemplatekey
+					);
 
 					templatePreview.html('<div class="loading-animation"></div>');
 
@@ -127,7 +117,7 @@ AssetRenderer<JournalArticle> assetRenderer = assetRendererFactory.getAssetRende
 						Liferay.Util.ns(
 							'<%= PortalUtil.getPortletNamespace(JournalContentPortletKeys.JOURNAL_CONTENT) %>',
 							{
-								ddmTemplateKey: event.ddmtemplatekey,
+								ddmTemplateKey: selectedItem.ddmtemplatekey,
 							}
 						)
 					);
@@ -169,8 +159,12 @@ AssetRenderer<JournalArticle> assetRenderer = assetRendererFactory.getAssetRende
 					}).render(form);
 
 					instance._alert = alert;
-				}
-			);
+				},
+				selectEventName:
+					'<%= PortalUtil.getPortletNamespace(portletId) + "selectDDMTemplate" %>',
+				title: '<liferay-ui:message key="templates" />',
+				url: '<%= selectDDMTemplateURL %>',
+			});
 		}
 	);
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/template.jsp
@@ -80,7 +80,7 @@ DDMTemplate ddmTemplate = journalEditArticleDisplayContext.getDDMTemplate();
 
 		if (previewWithTemplate) {
 			previewWithTemplate.addEventListener('click', function (event) {
-				var uri = '<%= previewArticleContentTemplateURL %>';
+				var url = '<%= previewArticleContentTemplateURL %>';
 
 				<%
 				long ddmTemplateId = 0;
@@ -106,9 +106,9 @@ DDMTemplate ddmTemplate = journalEditArticleDisplayContext.getDDMTemplate();
 							.<portlet:namespace />ddmTemplateId.value;
 				}
 
-				uri = Liferay.Util.addParams(
+				url = Liferay.Util.addParams(
 					'<portlet:namespace />ddmTemplateId=' + ddmTemplateId,
-					uri
+					url
 				);
 
 				var languageId = '<%= themeDisplay.getLanguageId() %>';
@@ -121,25 +121,19 @@ DDMTemplate ddmTemplate = journalEditArticleDisplayContext.getDDMTemplate();
 					languageId = inputComponent.getSelectedLanguageId();
 				}
 
-				uri = Liferay.Util.addParams(
+				url = Liferay.Util.addParams(
 					'<portlet:namespace />languageId=' + languageId,
-					uri
+					url
 				);
 
-				Liferay.Util.selectEntity(
-					{
-						dialog: {
-							destroyOnHide: true,
-						},
-						eventName: '<portlet:namespace />preview',
-						id: '<portlet:namespace />preview',
-						title: '<liferay-ui:message key="preview" />',
-						uri: uri,
+				Liferay.Util.openModal({
+					onSelect: function (selectedItem) {
+						changeDDMTemplate(selectedItem.ddmtemplateid);
 					},
-					function (event) {
-						changeDDMTemplate(event.ddmtemplateid);
-					}
-				);
+					selectEventName: '<portlet:namespace />preview',
+					title: '<liferay-ui:message key="preview" />',
+					url: url,
+				});
 			});
 		}
 	</c:if>
@@ -193,23 +187,15 @@ DDMTemplate ddmTemplate = journalEditArticleDisplayContext.getDDMTemplate();
 
 	if (selectDDMTemplateButton) {
 		selectDDMTemplateButton.addEventListener('click', function (event) {
-			Liferay.Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						destroyOnHide: true,
-						modal: true,
-					},
-					eventName: '<portlet:namespace />selectDDMTemplate',
-					id: '<portlet:namespace />selectDDMTemplate',
-					title: '<%= UnicodeLanguageUtil.get(request, "templates") %>',
-					uri:
-						'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/select_ddm_template.jsp" /><portlet:param name="ddmStructureId" value="<%= String.valueOf(ddmStructure.getStructureId()) %>" /></portlet:renderURL>',
+			Liferay.Util.openModal({
+				onSelect: function (selectedItem) {
+					changeDDMTemplate(selectedItem.ddmtemplateid);
 				},
-				function (event) {
-					changeDDMTemplate(event.ddmtemplateid);
-				}
-			);
+				selectEventName: '<portlet:namespace />selectDDMTemplate',
+				title: '<%= UnicodeLanguageUtil.get(request, "templates") %>',
+				url:
+					'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/select_ddm_template.jsp" /><portlet:param name="ddmStructureId" value="<%= String.valueOf(ddmStructure.getStructureId()) %>" /></portlet:renderURL>',
+			});
 		});
 	}
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/configuration/icon/view_source_icon.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/configuration/icon/view_source_icon.jsp
@@ -33,17 +33,10 @@ JournalArticle article = (JournalArticle)request.getAttribute(WebKeys.JOURNAL_AR
 
 	if (viewResourcesButton) {
 		viewResourcesButton.addEventListener('click', function (event) {
-			Liferay.Util.openWindow({
-				dialog: {
-					destroyOnHide: true,
-					modal: true,
-				},
-				dialogIframe: {
-					bodyCssClass: 'dialog-with-footer',
-				},
+			Liferay.Util.openModal({
 				title:
 					'<%= HtmlUtil.escapeJS(HtmlUtil.escape(article.getTitle(themeDisplay.getLocale()))) %>',
-				uri:
+				url:
 					'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/configuration/icon/view_source.jsp" /><portlet:param name="redirect" value="<%= currentURL %>" /><portlet:param name="groupId" value="<%= String.valueOf(article.getGroupId()) %>" /><portlet:param name="articleId" value="<%= article.getArticleId() %>" /><portlet:param name="status" value="<%= String.valueOf(article.getStatus()) %>" /></portlet:renderURL>',
 			});
 		});

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/ddm_template/basic_info.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/ddm_template/basic_info.jsp
@@ -91,30 +91,24 @@ DDMStructure ddmStructure = journalEditDDMTemplateDisplayContext.getDDMStructure
 
 		if (selectDDMStructure) {
 			selectDDMStructure.addEventListener('click', function (event) {
-				Liferay.Util.selectEntity(
-					{
-						dialog: {
-							constrain: true,
-							modal: true,
-						},
-						eventName: '<portlet:namespace />selectDDMStructure',
-						title: '<%= UnicodeLanguageUtil.get(request, "structures") %>',
-						uri:
-							'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/select_ddm_structure.jsp" /></portlet:renderURL>',
-					},
-					function (event) {
+				Liferay.Util.openModal({
+					onSelect: function (selectedItem) {
 						if (
 							document.<portlet:namespace />fm
 								.<portlet:namespace />classPK.value !=
-							event.ddmstructureid
+							selectedItem.ddmstructureid
 						) {
 							document.<portlet:namespace />fm.<portlet:namespace />classPK.value =
-								event.ddmstructureid;
+								selectedItem.ddmstructureid;
 
 							Liferay.fire('<portlet:namespace />refreshEditor');
 						}
-					}
-				);
+					},
+					selectEventName: '<portlet:namespace />selectDDMStructure',
+					title: '<%= UnicodeLanguageUtil.get(request, "structures") %>',
+					url:
+						'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/select_ddm_structure.jsp" /></portlet:renderURL>',
+				});
 			});
 		}
 	</aui:script>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_form_builder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_structure_form_builder.jsp
@@ -187,25 +187,15 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 
 <aui:script>
 	function <portlet:namespace />openParentDDMStructureSelector() {
-		Liferay.Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					modal: true,
-				},
-				eventName: '<portlet:namespace />selectDDMStructure',
-				id: '<portlet:namespace />selectDDMStructure',
-				title:
-					'<%= UnicodeLanguageUtil.get(request, "select-structure") %>',
-				uri:
-					'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/select_ddm_structure.jsp" /><portlet:param name="classPK" value="<%= String.valueOf(journalEditDDMStructuresDisplayContext.getDDMStructureId()) %>" /></portlet:renderURL>',
-			},
-			function (event) {
+		Liferay.Util.openModal({
+			onSelect: function (selectedItem) {
 				var form = document.<portlet:namespace />fm;
 
 				Liferay.Util.setFormValues(form, {
-					parentDDMStructureId: event.ddmstructureid,
-					parentDDMStructureName: Liferay.Util.unescape(event.name),
+					parentDDMStructureId: selectedItem.ddmstructureid,
+					parentDDMStructureName: Liferay.Util.unescape(
+						selectedItem.name
+					),
 				});
 
 				var removeParentDDMStructureButton = Liferay.Util.getFormElement(
@@ -219,8 +209,12 @@ editDDMStructureURL.setParameter("mvcPath", "/edit_ddm_structure.jsp");
 						false
 					);
 				}
-			}
-		);
+			},
+			selectEventName: '<portlet:namespace />selectDDMStructure',
+			title: '<%= UnicodeLanguageUtil.get(request, "select-structure") %>',
+			url:
+				'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/select_ddm_structure.jsp" /><portlet:param name="classPK" value="<%= String.valueOf(journalEditDDMStructuresDisplayContext.getDDMStructureId()) %>" /></portlet:renderURL>',
+		});
 	}
 
 	function <portlet:namespace />removeParentDDMStructure() {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
@@ -341,22 +341,12 @@ renderResponse.setTitle((feed == null) ? LanguageUtil.get(request, "new-feed") :
 
 <aui:script>
 	function <portlet:namespace />openDDMStructureSelector() {
-		Liferay.Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					modal: true,
-				},
-				eventName: '<portlet:namespace />selectDDMStructure',
-				title: '<%= UnicodeLanguageUtil.get(request, "structures") %>',
-				uri:
-					'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/select_ddm_structure.jsp" /></portlet:renderURL>',
-			},
-			function (event) {
+		Liferay.Util.openModal({
+			onSelect: function (selectedItem) {
 				if (
 					document.<portlet:namespace />fm
 						.<portlet:namespace />ddmStructureKey.value !=
-					event.ddmstructurekey
+					selectedItem.ddmstructurekey
 				) {
 					if (
 						confirm(
@@ -364,7 +354,7 @@ renderResponse.setTitle((feed == null) ? LanguageUtil.get(request, "new-feed") :
 						)
 					) {
 						document.<portlet:namespace />fm.<portlet:namespace />ddmStructureKey.value =
-							event.ddmstructurekey;
+							selectedItem.ddmstructurekey;
 						document.<portlet:namespace />fm.<portlet:namespace />ddmTemplateKey.value =
 							'';
 						document.<portlet:namespace />fm.<portlet:namespace />ddmRendererTemplateKey.value =
@@ -380,8 +370,12 @@ renderResponse.setTitle((feed == null) ? LanguageUtil.get(request, "new-feed") :
 						);
 					}
 				}
-			}
-		);
+			},
+			selectEventName: '<portlet:namespace />selectDDMStructure',
+			title: '<%= UnicodeLanguageUtil.get(request, "structures") %>',
+			url:
+				'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/select_ddm_structure.jsp" /></portlet:renderURL>',
+		});
 	}
 
 	function <portlet:namespace />removeDDMStructure() {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
@@ -393,21 +393,11 @@ renderResponse.setTitle(title);
 
 	if (selectDDMStructureButton) {
 		selectDDMStructureButton.addEventListener('click', function (event) {
-			Liferay.Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						modal: true,
-					},
-					eventName: '<portlet:namespace />selectDDMStructure',
-					title: '<%= UnicodeLanguageUtil.get(request, "structures") %>',
-					uri:
-						'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/select_ddm_structure.jsp" /></portlet:renderURL>',
-				},
-				function (event) {
+			Liferay.Util.openModal({
+				onSelect: function (selectedItem) {
 					var ddmStructureLink =
 						'<a class="modify-link" data-rowId="' +
-						event.ddmstructureid +
+						selectedItem.ddmstructureid +
 						'" href="javascript:;"><%= UnicodeFormatter.toString(removeDDMStructureIcon) %></a>';
 
 					<c:choose>
@@ -417,25 +407,29 @@ renderResponse.setTitle(title);
 
 							workflowDefinitions = workflowDefinitions.replace(
 								/LIFERAY_WORKFLOW_DEFINITION_DDM_STRUCTURE/g,
-								'workflowDefinition' + event.ddmstructureid
+								'workflowDefinition' + selectedItem.ddmstructureid
 							);
 
 							searchContainer.addRow(
-								[event.name, workflowDefinitions, ddmStructureLink],
-								event.ddmstructureid
+								[selectedItem.name, workflowDefinitions, ddmStructureLink],
+								selectedItem.ddmstructureid
 							);
 						</c:when>
 						<c:otherwise>
 							searchContainer.addRow(
-								[event.name, ddmStructureLink],
-								event.ddmstructureid
+								[selectedItem.name, ddmStructureLink],
+								selectedItem.ddmstructureid
 							);
 						</c:otherwise>
 					</c:choose>
 
 					searchContainer.updateDataStore();
-				}
-			);
+				},
+				selectEventName: '<portlet:namespace />selectDDMStructure',
+				title: '<%= UnicodeLanguageUtil.get(request, "structures") %>',
+				url:
+					'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/select_ddm_structure.jsp" /></portlet:renderURL>',
+			});
 		});
 	}
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DDMTemplateElementsDefaultEventHandler.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/DDMTemplateElementsDefaultEventHandler.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {DefaultEventHandler} from 'frontend-js-web';
+import {DefaultEventHandler, openModal} from 'frontend-js-web';
 
 class DDMTemplateElementsDefaultEventHandler extends DefaultEventHandler {
 	deleteDDMTemplate(itemData) {
@@ -26,16 +26,9 @@ class DDMTemplateElementsDefaultEventHandler extends DefaultEventHandler {
 	}
 
 	permissionsDDMTemplate(itemData) {
-		Liferay.Util.openWindow({
-			dialog: {
-				destroyOnHide: true,
-				modal: true,
-			},
-			dialogIframe: {
-				bodyCssClass: 'dialog-with-footer',
-			},
+		openModal({
 			title: Liferay.Language.get('permissions'),
-			uri: itemData.permissionsDDMTemplateURL,
+			url: itemData.permissionsDDMTemplateURL,
 		});
 	}
 }

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultEventHandler.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ElementsDefaultEventHandler.es.js
@@ -16,6 +16,7 @@ import {
 	DefaultEventHandler,
 	ItemSelectorDialog,
 	addParams,
+	openModal,
 } from 'frontend-js-web';
 import {Config} from 'metal-state';
 
@@ -23,33 +24,25 @@ class ElementsDefaultEventHandler extends DefaultEventHandler {
 	compareVersions(itemData) {
 		const namespace = this.namespace;
 
-		Liferay.Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					destroyOnHide: true,
-					modal: true,
-				},
-				eventName: this.ns('selectVersionFm'),
-				id: this.ns('compareVersions'),
-				title: Liferay.Language.get('compare-versions'),
-				uri: itemData.compareVersionsURL,
+		openModal({
+			onSelect: (selectedItem) => {
+				let url = itemData.redirectURL;
+
+				url = addParams(
+					`${namespace}sourceVersion=${selectedItem.sourceversion}`,
+					url
+				);
+				url = addParams(
+					`${namespace}targetVersion=${selectedItem.targetversion}`,
+					url
+				);
+
+				location.href = url;
 			},
-			(event) => {
-				let uri = itemData.redirectURL;
-
-				uri = addParams(
-					namespace + 'sourceVersion=' + event.sourceversion,
-					uri
-				);
-				uri = addParams(
-					namespace + 'targetVersion=' + event.targetversion,
-					uri
-				);
-
-				location.href = uri;
-			}
-		);
+			selectEventName: this.ns('selectVersionFm'),
+			title: Liferay.Language.get('compare-versions'),
+			url: itemData.compareVersionsURL,
+		});
 	}
 
 	copyArticle(itemData) {
@@ -103,30 +96,16 @@ class ElementsDefaultEventHandler extends DefaultEventHandler {
 	}
 
 	permissions(itemData) {
-		Liferay.Util.openWindow({
-			dialog: {
-				destroyOnHide: true,
-				modal: true,
-			},
-			dialogIframe: {
-				bodyCssClass: 'dialog-with-footer',
-			},
+		openModal({
 			title: Liferay.Language.get('permissions'),
-			uri: itemData.permissionsURL,
+			url: itemData.permissionsURL,
 		});
 	}
 
 	preview(itemData) {
-		Liferay.Util.openWindow({
-			dialog: {
-				destroyOnHide: true,
-				modal: true,
-			},
-			dialogIframe: {
-				bodyCssClass: 'dialog-with-footer',
-			},
+		openModal({
 			title: itemData.title,
-			uri: itemData.previewURL,
+			url: itemData.previewURL,
 		});
 	}
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ManagementToolbarDefaultEventHandler.es.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {DefaultEventHandler, addParams} from 'frontend-js-web';
+import {DefaultEventHandler, addParams, openModal} from 'frontend-js-web';
 import {Config} from 'metal-state';
 
 class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
@@ -108,28 +108,21 @@ class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	}
 
 	openDDMStructuresSelector() {
-		const namespace = this.namespace;
-		const uri = this.viewDDMStructureArticlesURL;
-
-		Liferay.Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					modal: true,
-				},
-				eventName: this.ns('selectDDMStructure'),
-				title: Liferay.Language.get('structures'),
-				uri: this.selectEntityURL,
-			},
-			(event) => {
+		openModal({
+			onSelect: (selectedItem) => {
 				Liferay.Util.navigate(
 					addParams(
-						namespace + 'ddmStructureKey=' + event.ddmstructurekey,
-						uri
+						this.namespace +
+							'ddmStructureKey=' +
+							selectedItem.ddmstructurekey,
+						this.viewDDMStructureArticlesURL
 					)
 				);
-			}
-		);
+			},
+			selectEventName: this.ns('selectDDMStructure'),
+			title: Liferay.Language.get('structures'),
+			url: this.selectEntityURL,
+		});
 	}
 }
 

--- a/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/bottom.jspf
+++ b/portal-web/docroot/html/taglib/ui/search_iterator/lexicon/bottom.jspf
@@ -93,51 +93,64 @@
 		).render();
 
 		<c:if test="<%= fixedHeader && displayStyle.equals(SearchIteratorTag.DEFAULT_DISPLAY_STYLE) %>">
-			var contentBox = searchContainer.get('contentBox');
+			var inModal = window !== Liferay.Util.getOpener();
 
-			var fixedHeader = document.getElementById('<%= namespace + id %>fixedHeader');
+			var initFixedHeaderSync = function() {
+				var contentBox = searchContainer.get('contentBox');
 
-			if (contentBox) {
-				var mainContent = contentBox.ancestor('#main-content');
-				var horizontalScrollingContainer = document.querySelector('.lfr-search-container-fixed-first-column .table-responsive');
-				var fixedHeaderScrollingContainer = document.querySelector('.lfr-search-iterator-fixed-header-inner-wrapper');
+				var fixedHeader = document.getElementById('<%= namespace + id %>fixedHeader');
 
-				if (mainContent && horizontalScrollingContainer && fixedHeaderScrollingContainer) {
-					var verticalScrollingContainer = window === Liferay.Util.getOpener() ? window : mainContent._node;
+				if (contentBox) {
+					var mainContent = contentBox.ancestor('#main-content');
+					var horizontalScrollingContainer = document.querySelector('.lfr-search-container-fixed-first-column .table-responsive');
+					var fixedHeaderScrollingContainer = document.querySelector('.lfr-search-iterator-fixed-header-inner-wrapper');
 
-					var table = fixedHeader.parentElement.parentElement;
-					var trDomRect = fixedHeader.previousElementSibling.getBoundingClientRect();
+					if (mainContent && horizontalScrollingContainer && fixedHeaderScrollingContainer) {
+						var verticalScrollingContainer = inModal ? mainContent._node : window;
 
-					var syncScrollingContainers = function(event) {
-						fixedHeaderScrollingContainer.scrollLeft = horizontalScrollingContainer.scrollLeft;
+						var table = fixedHeader.parentElement.parentElement;
+						var trDomRect = fixedHeader.previousElementSibling.getBoundingClientRect();
+
+						var syncScrollingContainers = function(event) {
+							fixedHeaderScrollingContainer.scrollLeft = horizontalScrollingContainer.scrollLeft;
+						}
+
+						var fixedHeaderEventHandler = function(event) {
+							var scrollTop = verticalScrollingContainer.scrollTop;
+							var trDomRecTop = trDomRect.top;
+
+							if (fixedHeader.classList.contains('hide') && (scrollTop >= trDomRecTop)) {
+								fixedHeader.classList.remove('hide');
+
+								syncScrollingContainers();
+							}
+							else if (verticalScrollingContainer.scrollTop < trDomRecTop) {
+								fixedHeader.classList.add('hide');
+							}
+						};
+
+						verticalScrollingContainer.addEventListener('scroll', fixedHeaderEventHandler);
+
+						horizontalScrollingContainer.addEventListener('scroll', syncScrollingContainers);
+
+						Liferay.on(
+							'destroyPortlet',
+							function() {
+								verticalScrollingContainer.removeEventListener('scroll', fixedHeaderEventHandler);
+								horizontalScrollingContainer.removeEventListener('scroll', syncScrollingContainers);
+							}
+						);
 					}
-
-					var fixedHeaderEventHandler = function(event) {
-						var scrollTop = verticalScrollingContainer.scrollTop;
-						var trDomRecTop = trDomRect.top;
-
-						if (fixedHeader.classList.contains('hide') && (scrollTop >= trDomRecTop)) {
-							fixedHeader.classList.remove('hide');
-
-							syncScrollingContainers();
-						}
-						else if (verticalScrollingContainer.scrollTop < trDomRecTop) {
-							fixedHeader.classList.add('hide');
-						}
-					};
-
-					verticalScrollingContainer.addEventListener('scroll', fixedHeaderEventHandler);
-
-					horizontalScrollingContainer.addEventListener('scroll', syncScrollingContainers);
-
-					Liferay.on(
-						'destroyPortlet',
-						function() {
-							verticalScrollingContainer.removeEventListener('scroll', fixedHeaderEventHandler);
-							horizontalScrollingContainer.removeEventListener('scroll', syncScrollingContainers);
-						}
-					);
 				}
+			}
+
+			if (inModal) {
+				Liferay.Util.getOpener().Liferay.on('modalIframeLoaded', function() {
+					initFixedHeaderSync();
+				});
+			}
+			else {
+				initFixedHeaderSync();
 			}
 		</c:if>
 


### PR DESCRIPTION
Hey @wincent ,

This is a followup on https://github.com/wincent/liferay-portal/pull/268

Changes are in the added commit. There was a bug in the permissions modal, all of the tabs > item options > Permissions. The fixed table header did not work correctly. In the new modal, we are always showing loading indicator, during which iframe content is hidden. As the fixed table header was eagerly initializing, it initialized on hidden table and this messed up height and width calculations. Now, we are initializing on `modalIframeLoaded` event. I also needed to tweak utility, we were firing the event a bit too early, before component got the chance to update and show content. Hopefully this tweak will not cause CI test issues.

Here is a screenshot of how fixed table header should look:
![screen](https://user-images.githubusercontent.com/5435511/82428857-64c53980-9a8b-11ea-9dd3-b7bb7ef235a7.png)

Please review the code,

Thank you!

/cc @jbalsas