### PR TITLE
LPS-112988 Replace Global Menu markup and refactor js

### DIFF
--- a/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements_admin/view.jsp
+++ b/modules/apps/announcements/announcements-web/src/main/resources/META-INF/resources/announcements_admin/view.jsp
@@ -46,7 +46,6 @@ AnnouncementsAdminViewManagementToolbarDisplayContext announcementsAdminViewMana
 %>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems='<%=
 		new JSPNavigationItemList(pageContext) {
 			{

--- a/modules/apps/app-builder/app-builder-web/src/main/java/com/liferay/app/builder/web/internal/application/list/AppBuilderPanelCategory.java
+++ b/modules/apps/app-builder/app-builder-web/src/main/java/com/liferay/app/builder/web/internal/application/list/AppBuilderPanelCategory.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Component;
 @Component(
 	immediate = true,
 	property = {
-		"panel.category.key=" + PanelCategoryKeys.CONTROL_PANEL,
+		"panel.category.key=" + PanelCategoryKeys.GLOBAL_MENU_APPLICATIONS,
 		"panel.category.order:Integer=600"
 	},
 	service = PanelCategory.class

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/application/list/ChangeListsPanelCategory.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/application/list/ChangeListsPanelCategory.java
@@ -33,7 +33,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	immediate = true,
 	property = {
-		"panel.category.key=" + PanelCategoryKeys.CONTROL_PANEL,
+		"panel.category.key=" + PanelCategoryKeys.GLOBAL_MENU_APPLICATIONS,
 		"panel.category.order:Integer=900"
 	},
 	service = PanelCategory.class

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ChangeListsConfigurationDisplayContext.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/display/context/ChangeListsConfigurationDisplayContext.java
@@ -16,14 +16,10 @@ package com.liferay.change.tracking.web.internal.display.context;
 
 import com.liferay.change.tracking.model.CTPreferences;
 import com.liferay.change.tracking.service.CTPreferencesLocalService;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
-
-import java.util.List;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.PortletURL;
@@ -87,22 +83,6 @@ public class ChangeListsConfigurationDisplayContext {
 		}
 
 		return _navigation;
-	}
-
-	public List<NavigationItem> getViewNavigationItems() {
-		return NavigationItemListBuilder.add(
-			navigationItem -> {
-				String navigation = getNavigation();
-
-				navigationItem.setActive(navigation.equals("global-settings"));
-
-				navigationItem.setHref(
-					_renderResponse.createRenderURL(), "navigation",
-					"global-settings");
-				navigationItem.setLabel(
-					_language.get(_httpServletRequest, "global-settings"));
-			}
-		).build();
 	}
 
 	public boolean isChangeListsEnabled() {

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view.jsp
@@ -23,7 +23,6 @@ ChangeListsManagementToolbarDisplayContext changeListsManagementToolbarDisplayCo
 %>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems="<%= changeListsDisplayContext.getViewNavigationItems() %>"
 />
 

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_history.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists/view_history.jsp
@@ -27,7 +27,6 @@ Format format = FastDateFormatFactoryUtil.getDateTime(locale, timeZone);
 %>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems="<%= viewHistoryDisplayContext.getViewNavigationItems() %>"
 />
 

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists_configuration/view.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists_configuration/view.jsp
@@ -17,7 +17,6 @@
 <%@ include file="/change_lists_configuration/init.jsp" %>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems="<%= changeListsConfigurationDisplayContext.getViewNavigationItems() %>"
 />
 

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists_configuration/view.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/change_lists_configuration/view.jsp
@@ -16,10 +16,6 @@
 
 <%@ include file="/change_lists_configuration/init.jsp" %>
 
-<clay:navigation-bar
-	navigationItems="<%= changeListsConfigurationDisplayContext.getViewNavigationItems() %>"
-/>
-
 <clay:container-fluid
 	className="container-form-lg"
 >

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/application/list/DepotAdminPanelCategory.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/application/list/DepotAdminPanelCategory.java
@@ -37,7 +37,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	immediate = true,
 	property = {
-		"panel.category.key=" + PanelCategoryKeys.CONTROL_PANEL,
+		"panel.category.key=" + PanelCategoryKeys.GLOBAL_MENU_APPLICATIONS,
 		"panel.category.order:Integer=301"
 	},
 	service = PanelCategory.class

--- a/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/view_attributes.jsp
+++ b/modules/apps/expando/expando-web/src/main/resources/META-INF/resources/view_attributes.jsp
@@ -46,7 +46,6 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "view-at
 %>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems='<%= expandoDisplayContext.getNavigationItems("fields") %>'
 />
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/build.gradle
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:frontend-js:frontend-js-loader-modules-extender-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
 	compileOnly project(":apps:portal-template:portal-template-soy-api")

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/display/context/AppManagerDisplayContext.java
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/java/com/liferay/marketplace/app/manager/web/internal/display/context/AppManagerDisplayContext.java
@@ -59,17 +59,6 @@ public class AppManagerDisplayContext {
 		).build();
 	}
 
-	public List<NavigationItem> getNavigationItems(String url, String label) {
-		return NavigationItemListBuilder.add(
-			navigationItem -> {
-				navigationItem.setActive(true);
-				navigationItem.setHref(url);
-				navigationItem.setLabel(
-					LanguageUtil.get(_httpServletRequest, label));
-			}
-		).build();
-	}
-
 	private String _getViewModuleURL(String pluginType) {
 		String app = ParamUtil.getString(_httpServletRequest, "app");
 		String moduleGroup = ParamUtil.getString(

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view.jsp
@@ -25,7 +25,6 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "app-man
 <portlet:renderURL var="viewURL" />
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems='<%= appManagerDisplayContext.getNavigationItems(viewURL, "apps") %>'
 />
 

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view.jsp
@@ -24,10 +24,6 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "app-man
 
 <portlet:renderURL var="viewURL" />
 
-<clay:navigation-bar
-	navigationItems='<%= appManagerDisplayContext.getNavigationItems(viewURL, "apps") %>'
-/>
-
 <clay:management-toolbar
 	clearResultsURL="<%= viewAppsManagerManagementToolbarDisplayContext.getClearResultsURL() %>"
 	filterDropdownItems="<%= viewAppsManagerManagementToolbarDisplayContext.getFilterDropdownItems() %>"

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_module.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_module.jsp
@@ -60,7 +60,6 @@ else {
 %>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems="<%= appManagerDisplayContext.getModuleNavigationItems() %>"
 />
 

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_modules.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_modules.jsp
@@ -42,10 +42,6 @@ MarketplaceAppManagerUtil.addPortletBreadcrumbEntry(appDisplay, request, renderR
 	<portlet:param name="app" value="<%= app %>" />
 </portlet:renderURL>
 
-<clay:navigation-bar
-	navigationItems='<%= appManagerDisplayContext.getNavigationItems(viewURL, "modules") %>'
-/>
-
 <clay:management-toolbar
 	filterDropdownItems="<%= viewModulesManagementToolbarDisplayContext.getFilterDropdownItems() %>"
 	searchActionURL="<%= viewModulesManagementToolbarDisplayContext.getSearchActionURL() %>"

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_modules.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_modules.jsp
@@ -43,7 +43,6 @@ MarketplaceAppManagerUtil.addPortletBreadcrumbEntry(appDisplay, request, renderR
 </portlet:renderURL>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems='<%= appManagerDisplayContext.getNavigationItems(viewURL, "modules") %>'
 />
 

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_search_results.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_search_results.jsp
@@ -33,7 +33,6 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "search-
 <portlet:renderURL var="viewURL" />
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems='<%= appManagerDisplayContext.getNavigationItems(viewURL, "search") %>'
 />
 

--- a/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_search_results.jsp
+++ b/modules/apps/marketplace/marketplace-app-manager-web/src/main/resources/META-INF/resources/view_search_results.jsp
@@ -32,10 +32,6 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "search-
 
 <portlet:renderURL var="viewURL" />
 
-<clay:navigation-bar
-	navigationItems='<%= appManagerDisplayContext.getNavigationItems(viewURL, "search") %>'
-/>
-
 <%
 AppManagerSearchResultsManagementToolbarDisplayContext
 	appManagerSearchResultsManagementToolbarDisplayContext = new AppManagerSearchResultsManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse);

--- a/modules/apps/monitoring/monitoring-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/monitoring/monitoring-web/src/main/resources/META-INF/resources/init.jsp
@@ -24,9 +24,7 @@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.JSPNavigationItemList" %><%@
-page import="com.liferay.petra.string.StringPool" %><%@
-page import="com.liferay.portal.kernel.exception.NoSuchUserException" %><%@
+<%@ page import="com.liferay.portal.kernel.exception.NoSuchUserException" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.log.Log" %><%@
 page import="com.liferay.portal.kernel.log.LogFactoryUtil" %><%@

--- a/modules/apps/monitoring/monitoring-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/monitoring/monitoring-web/src/main/resources/META-INF/resources/view.jsp
@@ -38,21 +38,6 @@ PortletURL sortingURL = PortletURLUtil.clone(portletURL, renderResponse);
 sortingURL.setParameter("orderByType", orderByType.equals("asc") ? "desc" : "asc");
 %>
 
-<clay:navigation-bar
-	navigationItems='<%=
-		new JSPNavigationItemList(pageContext) {
-			{
-				add(
-					navigationItem -> {
-						navigationItem.setActive(true);
-						navigationItem.setHref(StringPool.BLANK);
-						navigationItem.setLabel(LanguageUtil.get(request, "live-sessions"));
-					});
-			}
-		}
-	%>'
-/>
-
 <clay:management-toolbar
 	disabled="<%= ListUtil.isEmpty(userTrackers) %>"
 	selectable="<%= false %>"

--- a/modules/apps/monitoring/monitoring-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/monitoring/monitoring-web/src/main/resources/META-INF/resources/view.jsp
@@ -39,7 +39,6 @@ sortingURL.setParameter("orderByType", orderByType.equals("asc") ? "desc" : "asc
 %>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems='<%=
 		new JSPNavigationItemList(pageContext) {
 			{

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application.jsp
@@ -50,7 +50,6 @@ if (request.getAttribute(OAuth2ProviderWebKeys.ASSIGN_SCOPES_TREE_DISPLAY_CONTEX
 
 <c:if test="<%= oAuth2Application != null %>">
 	<clay:navigation-bar
-		inverted="<%= true %>"
 		navigationItems='<%=
 				new JSPNavigationItemList(pageContext) {
 				{

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/java/com/liferay/password/policies/admin/web/internal/display/context/PasswordPolicyDisplayContext.java
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/java/com/liferay/password/policies/admin/web/internal/display/context/PasswordPolicyDisplayContext.java
@@ -16,7 +16,6 @@ package com.liferay.password.policies.admin.web.internal.display.context;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
@@ -26,7 +25,6 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.portlet.PortletException;
@@ -130,39 +128,6 @@ public class PasswordPolicyDisplayContext {
 		if (navigationItems.isEmpty()) {
 			return null;
 		}
-
-		return navigationItems;
-	}
-
-	public List<NavigationItem> getSelectMembersNavigationItems() {
-		String tabs2 = ParamUtil.getString(
-			_httpServletRequest, "tabs2", "users");
-
-		List<NavigationItem> navigationItems = new ArrayList<>();
-
-		NavigationItem entriesNavigationItem = new NavigationItem();
-
-		entriesNavigationItem.setActive(true);
-		entriesNavigationItem.setHref(StringPool.BLANK);
-		entriesNavigationItem.setLabel(
-			LanguageUtil.get(_httpServletRequest, tabs2));
-
-		navigationItems.add(entriesNavigationItem);
-
-		return navigationItems;
-	}
-
-	public List<NavigationItem> getViewPasswordPoliciesNavigationItems() {
-		List<NavigationItem> navigationItems = new ArrayList<>();
-
-		NavigationItem entriesNavigationItem = new NavigationItem();
-
-		entriesNavigationItem.setActive(true);
-		entriesNavigationItem.setHref(StringPool.BLANK);
-		entriesNavigationItem.setLabel(
-			LanguageUtil.get(_httpServletRequest, "password-policies"));
-
-		navigationItems.add(entriesNavigationItem);
 
 		return navigationItems;
 	}

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/edit_password_policy_tabs.jsp
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/edit_password_policy_tabs.jsp
@@ -17,6 +17,5 @@
 <%@ include file="/init.jsp" %>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems="<%= passwordPolicyDisplayContext.getEditPasswordPolicyNavigationItems() %>"
 />

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -33,13 +33,7 @@ boolean passwordPolicyEnabled = LDAPSettingsUtil.isPasswordPolicyEnabled(company
 String description = LanguageUtil.get(request, "javax.portlet.description.com_liferay_password_policies_admin_web_portlet_PasswordPoliciesAdminPortlet") + " " + LanguageUtil.get(request, "when-no-password-policy-is-assigned-to-a-user,-either-explicitly-or-through-an-organization,-the-default-password-policy-is-used");
 
 portletDisplay.setDescription(description);
-%>
 
-<clay:navigation-bar
-	navigationItems="<%= passwordPolicyDisplayContext.getViewPasswordPoliciesNavigationItems() %>"
-/>
-
-<%
 ViewPasswordPoliciesManagementToolbarDisplayContext viewPasswordPoliciesManagementToolbarDisplayContext = new ViewPasswordPoliciesManagementToolbarDisplayContext(request, renderRequest, renderResponse, displayStyle);
 
 SearchContainer searchContainer = viewPasswordPoliciesManagementToolbarDisplayContext.getSearchContainer();

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -36,7 +36,6 @@ portletDisplay.setDescription(description);
 %>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems="<%= passwordPolicyDisplayContext.getViewPasswordPoliciesNavigationItems() %>"
 />
 

--- a/modules/apps/plugins-admin/plugins-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/plugins-admin/plugins-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -30,7 +30,6 @@ boolean showEditPluginHREF = true;
 %>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems='<%=
 		new JSPNavigationItemList(pageContext) {
 			{

--- a/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portal-search/portal-search-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -35,7 +35,6 @@ String selectedTab = searchAdminDisplayContext.getSelectedTab();
 %>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems="<%= searchAdminDisplayContext.getNavigationItemList() %>"
 />
 

--- a/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/navigation.jsp
+++ b/modules/apps/portal-workflow/portal-workflow-web/src/main/resources/META-INF/resources/navigation.jsp
@@ -22,7 +22,6 @@ WorkflowNavigationDisplayContext workflowNavigationDisplayContext = (WorkflowNav
 
 <c:if test="<%= workflowPortletTabs.size() != 1 %>">
 	<clay:navigation-bar
-		inverted="<%= true %>"
 		navigationItems="<%= workflowNavigationDisplayContext.getNavigationItems(selectedWorkflowPortletTab, workflowPortletTabs) %>"
 	/>
 </c:if>

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
@@ -210,6 +210,16 @@ a.control-menu-icon,
 	width: 32px;
 }
 
+.global-menu-app {
+	.control-menu-level-1 {
+		background-color: $white;
+	}
+
+	.control-menu-level-1-heading {
+		color: $black;
+	}
+}
+
 .tools-control-group {
 	flex: 1;
 	flex-wrap: wrap;

--- a/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/internal/application/list/ControlPanelCategory.java
+++ b/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/internal/application/list/ControlPanelCategory.java
@@ -36,7 +36,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	immediate = true,
 	property = {
-		"panel.category.key=" + PanelCategoryKeys.ROOT,
+		"panel.category.key=" + PanelCategoryKeys.GLOBAL_MENU,
 		"panel.category.order:Integer=100"
 	},
 	service = PanelCategory.class

--- a/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/internal/application/list/WorkflowPanelCategory.java
+++ b/modules/apps/product-navigation/product-navigation-control-panel/src/main/java/com/liferay/product/navigation/control/panel/internal/application/list/WorkflowPanelCategory.java
@@ -29,7 +29,7 @@ import org.osgi.service.component.annotations.Component;
 @Component(
 	immediate = true,
 	property = {
-		"panel.category.key=" + PanelCategoryKeys.CONTROL_PANEL,
+		"panel.category.key=" + PanelCategoryKeys.GLOBAL_MENU_APPLICATIONS,
 		"panel.category.order:Integer=500"
 	},
 	service = PanelCategory.class

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/global_menu/global_menu.jsp
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/global_menu/global_menu.jsp
@@ -20,7 +20,7 @@
 GlobalMenuDisplayContext globalMenuDisplayContext = new GlobalMenuDisplayContext(request);
 %>
 
-<div>
+<li class="control-menu-nav-item">
 	<clay:button
 		elementClasses="lfr-portal-tooltip"
 		icon="grid"
@@ -33,4 +33,4 @@ GlobalMenuDisplayContext globalMenuDisplayContext = new GlobalMenuDisplayContext
 		data="<%= globalMenuDisplayContext.getGlobalMenuComponentData() %>"
 		module="js/GlobalMenu"
 	/>
-</div>
+</li>

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
@@ -13,136 +13,172 @@
  */
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
-import ClayModal, {useModal} from '@clayui/modal';
+import ClaySticker from '@clayui/sticker';
 import ClayTabs from '@clayui/tabs';
+import classNames from 'classnames';
+import {useEventListener} from 'frontend-js-react-web';
 import {fetch} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useRef, useState} from 'react';
 
-const Column = ({panelApps}) => {
-	return (
-		<ul className="list-unstyled mt-4" role="list">
-			{panelApps.map(({label, portletId, url}) => (
-				<li className="mb-2" key={portletId}>
-					<a className="text-secondary" href={url}>
-						{label}
-					</a>
-				</li>
-			))}
-		</ul>
-	);
-};
-
-const Content = ({
-	childCategories,
+const AppsPanel = ({
+	categories = [],
 	portletNamespace,
 	recentSites,
 	viewAllURL,
 }) => {
+	const [activeTab, setActiveTab] = useState(0);
+
 	return (
-		<div className="row">
-			{childCategories.map(({key, label, panelApps}) => (
-				<div className="col p-4" key={key}>
-					<h2 className="h5 text-secondary text-uppercase">
-						{label}
-					</h2>
-
-					<Column panelApps={panelApps} />
-				</div>
-			))}
-
-			<div className="bg-lighter col p-4 rounded-sm" key="sites">
-				<h2 className="h5 mb-5 text-secondary text-uppercase">
-					{Liferay.Language.get('sites')}
-				</h2>
-
-				<p className="h6 mb-0 text-secondary text-uppercase">
-					{Liferay.Language.get('recently-visited')}
-				</p>
-
-				<ul className="list-unstyled mt-3" role="list">
-					{recentSites.map(({key, label, logoURL, url}) => (
-						<li className="mb-2" key={key}>
-							<div className="autofit-row autofit-row-center">
-								<div className="autofit-col mr-2">
-									<div className="sticker sticker-secondary">
-										<img
-											className="sticker-img"
-											src={logoURL}
-										/>
-									</div>
-								</div>
-
-								<div className="autofit-col autofit-col-expand">
-									<a className="text-secondary" href={url}>
-										{label}
-									</a>
-								</div>
-							</div>
-						</li>
+		<>
+			<div className="c-px-md-3 row">
+				<ClayTabs modern>
+					{categories.map(({key, label}, index) => (
+						<ClayTabs.Item
+							active={activeTab === index}
+							id={`${portletNamespace}tab_${index}`}
+							key={key}
+							onClick={() => setActiveTab(index)}
+						>
+							{label}
+						</ClayTabs.Item>
 					))}
-				</ul>
-
-				<ClayButton
-					displayType="link"
-					onClick={() => {
-						Liferay.Util.selectEntity(
-							{
-								dialog: {
-									constrain: true,
-									destroyOnHide: true,
-									modal: true,
-								},
-								eventName: `${portletNamespace}selectSite`,
-								id: `${portletNamespace}selectSite`,
-								title: Liferay.Language.get(
-									'select-site-or-asset-library'
-								),
-								uri: viewAllURL,
-							},
-							(event) => {
-								location.href = event.url;
-							}
-						);
-					}}
-				>
-					{Liferay.Language.get('view-all')}
-				</ClayButton>
+				</ClayTabs>
 			</div>
-		</div>
+
+			<ClayTabs.Content activeIndex={activeTab}>
+				{categories.map(({childCategories}, index) => (
+					<ClayTabs.TabPane
+						aria-labelledby={`${portletNamespace}tab_${index}`}
+						key={`tabPane-${index}`}
+					>
+						<div className="c-p-md-3 row">
+							{childCategories.map(({key, label, panelApps}) => (
+								<div className="col-md" key={key}>
+									<ul className="list-unstyled">
+										<li className="dropdown-subheader">
+											{label}
+										</li>
+
+										{panelApps.map(
+											({label, portletId, url}) => (
+												<li key={portletId}>
+													<a
+														className="dropdown-item"
+														href={url}
+													>
+														{label}
+													</a>
+												</li>
+											)
+										)}
+									</ul>
+								</div>
+							))}
+
+							<div className="col-md">
+								<ul className="bg-light list-unstyled rounded">
+									<li className="dropdown-subheader">
+										{Liferay.Language.get('sites')}
+									</li>
+
+									<li className="dropdown-subheader">
+										{Liferay.Language.get(
+											'recently-visited'
+										)}
+									</li>
+
+									{recentSites.map(
+										({key, label, logoURL, url}) => (
+											<li key={key}>
+												<a
+													className="dropdown-item"
+													href={url}
+												>
+													<ClaySticker
+														inline={true}
+														size="sm"
+													>
+														<img
+															className="sticker-img"
+															src={logoURL}
+														/>
+													</ClaySticker>
+
+													{label}
+												</a>
+											</li>
+										)
+									)}
+
+									<li>
+										<ClayButton
+											displayType="link"
+											onClick={() => {
+												Liferay.Util.selectEntity(
+													{
+														dialog: {
+															constrain: true,
+															destroyOnHide: true,
+															modal: true,
+														},
+														eventName: `${portletNamespace}selectSite`,
+														id: `${portletNamespace}selectSite`,
+														title: Liferay.Language.get(
+															'select-site-or-asset-library'
+														),
+														uri: viewAllURL,
+													},
+													(event) => {
+														location.href =
+															event.url;
+													}
+												);
+											}}
+										>
+											{Liferay.Language.get('view-all')}
+										</ClayButton>
+									</li>
+								</ul>
+							</div>
+						</div>
+					</ClayTabs.TabPane>
+				))}
+			</ClayTabs.Content>
+		</>
 	);
 };
 
-function GlobalMenu({panelAppsURL}) {
-	const [visible, setVisible] = useState(false);
-	const {observer} = useModal({
-		onClose: () => setVisible(false),
-	});
+const GlobalMenu = ({panelAppsURL}) => {
+	const [appsPanelData, setAppsPanelData] = useState({});
+	const [panelVisible, setPanelVisible] = useState(false);
 
-	const [activeTab, setActiveTab] = useState(0);
-	const [panelAppsData, setPanelAppsData] = useState({});
+	const elementRef = useRef();
+	const preloadPromiseRef = useRef();
 
-	const preloadPromise = useRef();
-
-	const {
-		items = [],
-		portletNamespace,
-		recentSites,
-		viewAllURL,
-	} = panelAppsData;
-
-	const handleOnClick = () => {
-		preloadItems();
-		showMenu();
+	const handleButtonOnClick = () => {
+		fetchCategories();
+		setPanelVisible(!panelVisible);
 	};
 
-	const preloadItems = () => {
-		if (!preloadPromise.current) {
-			preloadPromise.current = fetch(panelAppsURL)
+	useEventListener(
+		'click',
+		(event) => {
+			if (!elementRef.current.contains(event.target)) {
+				setPanelVisible(false);
+			}
+		},
+		true,
+		window
+	);
+
+	const fetchCategories = () => {
+		if (!preloadPromiseRef.current) {
+			preloadPromiseRef.current = fetch(panelAppsURL)
 				.then((response) => response.json())
 				.then(({items, portletNamespace, recentSites, viewAllURL}) => {
-					setPanelAppsData({
-						items,
+					setAppsPanelData({
+						categories: items,
 						portletNamespace,
 						recentSites,
 						viewAllURL,
@@ -151,60 +187,31 @@ function GlobalMenu({panelAppsURL}) {
 		}
 	};
 
-	const showMenu = () => {
-		setVisible(true);
-	};
-
 	return (
-		<>
-			{visible && (
-				<ClayModal observer={observer} size="full-screen" status="info">
-					<ClayModal.Body>
-						<ClayTabs modern>
-							{items.map(({key, label}, index) => (
-								<ClayTabs.Item
-									active={activeTab === index}
-									id={`${portletNamespace}tab_${index}`}
-									key={key}
-									onClick={() => setActiveTab(index)}
-								>
-									{label}
-								</ClayTabs.Item>
-							))}
-						</ClayTabs>
-
-						<div className="mt-4">
-							<ClayTabs.Content activeIndex={activeTab}>
-								{items.map(({childCategories}, index) => (
-									<ClayTabs.TabPane
-										aria-labelledby={`${portletNamespace}tab_${index}`}
-										key={`tabPane-${index}`}
-									>
-										<Content
-											childCategories={childCategories}
-											portletNamespace={portletNamespace}
-											recentSites={recentSites}
-											viewAllURL={viewAllURL}
-										/>
-									</ClayTabs.TabPane>
-								))}
-							</ClayTabs.Content>
-						</div>
-					</ClayModal.Body>
-				</ClayModal>
-			)}
-
+		<div
+			className="dropdown dropdown-full dropdown-global-app nav-item"
+			ref={elementRef}
+		>
 			<ClayButtonWithIcon
-				className="lfr-portal-tooltip"
+				className="dropdown-toggle lfr-portal-tooltip"
 				displayType="unstyled"
-				onClick={handleOnClick}
-				onFocus={preloadItems}
+				onClick={handleButtonOnClick}
+				onFocus={fetchCategories}
+				onHover={fetchCategories}
 				symbol="grid"
 				title={Liferay.Language.get('global-menu')}
 			/>
-		</>
+
+			<ul
+				className={classNames('dropdown-menu', {
+					show: panelVisible,
+				})}
+			>
+				<AppsPanel {...appsPanelData} />
+			</ul>
+		</div>
 	);
-}
+};
 
 GlobalMenu.propTypes = {
 	panelAppsURL: PropTypes.string,

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
@@ -184,7 +184,7 @@ const GlobalMenu = ({panelAppsURL}) => {
 						viewAllURL,
 					});
 				})
-				.cath(() => {
+				.catch(() => {
 					fetchCategoriesPromiseRef.current = null;
 				});
 		}

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
@@ -120,18 +120,28 @@ function GlobalMenu({panelAppsURL}) {
 	});
 
 	const [activeTab, setActiveTab] = useState(0);
-	const [context, setContext] = useState({});
+	const [panelAppsData, setPanelAppsData] = useState({});
 
 	const preloadPromise = useRef();
 
-	const {items = [], portletNamespace, recentSites, viewAllURL} = context;
+	const {
+		items = [],
+		portletNamespace,
+		recentSites,
+		viewAllURL,
+	} = panelAppsData;
 
-	function preloadItems() {
+	const handleOnClick = () => {
+		preloadItems();
+		showMenu();
+	};
+
+	const preloadItems = () => {
 		if (!preloadPromise.current) {
 			preloadPromise.current = fetch(panelAppsURL)
 				.then((response) => response.json())
 				.then(({items, portletNamespace, recentSites, viewAllURL}) => {
-					setContext({
+					setPanelAppsData({
 						items,
 						portletNamespace,
 						recentSites,
@@ -139,7 +149,11 @@ function GlobalMenu({panelAppsURL}) {
 					});
 				});
 		}
-	}
+	};
+
+	const showMenu = () => {
+		setVisible(true);
+	};
 
 	return (
 		<>
@@ -181,13 +195,9 @@ function GlobalMenu({panelAppsURL}) {
 			)}
 
 			<ClayButtonWithIcon
-				className={'lfr-portal-tooltip'}
+				className="lfr-portal-tooltip"
 				displayType="unstyled"
-				onClick={() => {
-					preloadItems();
-
-					setVisible(true);
-				}}
+				onClick={handleOnClick}
 				onFocus={preloadItems}
 				symbol="grid"
 				title={Liferay.Language.get('global-menu')}

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
@@ -154,7 +154,7 @@ const GlobalMenu = ({panelAppsURL}) => {
 	const [panelVisible, setPanelVisible] = useState(false);
 
 	const elementRef = useRef();
-	const preloadPromiseRef = useRef();
+	const fetchCategoriesPromiseRef = useRef();
 
 	const handleButtonOnClick = () => {
 		fetchCategories();
@@ -173,8 +173,8 @@ const GlobalMenu = ({panelAppsURL}) => {
 	);
 
 	const fetchCategories = () => {
-		if (!preloadPromiseRef.current) {
-			preloadPromiseRef.current = fetch(panelAppsURL)
+		if (!fetchCategoriesPromiseRef.current) {
+			fetchCategoriesPromiseRef.current = fetch(panelAppsURL)
 				.then((response) => response.json())
 				.then(({items, portletNamespace, recentSites, viewAllURL}) => {
 					setAppsPanelData({
@@ -183,6 +183,9 @@ const GlobalMenu = ({panelAppsURL}) => {
 						recentSites,
 						viewAllURL,
 					});
+				})
+				.cath(() => {
+					fetchCategoriesPromiseRef.current = null;
 				});
 		}
 	};

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
@@ -164,7 +164,7 @@ const GlobalMenu = ({panelAppsURL}) => {
 	useEventListener(
 		'click',
 		(event) => {
-			if (!elementRef.current.contains(event.target)) {
+			if (!elementRef.current?.contains(event.target)) {
 				setPanelVisible(false);
 			}
 		},

--- a/modules/apps/product-navigation/product-navigation-taglib/build.gradle
+++ b/modules/apps/product-navigation/product-navigation-taglib/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
 	compileOnly project(":apps:product-navigation:product-navigation-control-menu-api")

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/java/com/liferay/product/navigation/taglib/internal/servlet/ServletContextUtil.java
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/java/com/liferay/product/navigation/taglib/internal/servlet/ServletContextUtil.java
@@ -14,6 +14,8 @@
 
 package com.liferay.product.navigation.taglib.internal.servlet;
 
+import com.liferay.application.list.PanelAppRegistry;
+import com.liferay.application.list.PanelCategoryRegistry;
 import com.liferay.product.navigation.control.menu.util.ProductNavigationControlMenuCategoryRegistry;
 import com.liferay.product.navigation.control.menu.util.ProductNavigationControlMenuEntryRegistry;
 
@@ -32,6 +34,14 @@ public class ServletContextUtil {
 		return _servletContext.getContextPath();
 	}
 
+	public static final PanelAppRegistry getPanelAppRegistry() {
+		return _panelAppRegistry;
+	}
+
+	public static final PanelCategoryRegistry getPanelCategoryRegistry() {
+		return _panelCategoryRegistry;
+	}
+
 	public static final ProductNavigationControlMenuCategoryRegistry
 		getProductNavigationControlMenuCategoryRegistry() {
 
@@ -46,6 +56,18 @@ public class ServletContextUtil {
 
 	public static final ServletContext getServletContext() {
 		return _servletContext;
+	}
+
+	@Reference(unbind = "-")
+	protected void setPanelAppRegistry(PanelAppRegistry panelAppRegistry) {
+		_panelAppRegistry = panelAppRegistry;
+	}
+
+	@Reference(unbind = "-")
+	protected void setPanelCategoryRegistry(
+		PanelCategoryRegistry panelCategoryRegistry) {
+
+		_panelCategoryRegistry = panelCategoryRegistry;
 	}
 
 	@Reference(unbind = "-")
@@ -74,6 +96,8 @@ public class ServletContextUtil {
 		_servletContext = servletContext;
 	}
 
+	private static PanelAppRegistry _panelAppRegistry;
+	private static PanelCategoryRegistry _panelCategoryRegistry;
 	private static ProductNavigationControlMenuCategoryRegistry
 		_productNavigationControlMenuCategoryRegistry;
 	private static ProductNavigationControlMenuEntryRegistry

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/java/com/liferay/product/navigation/taglib/servlet/taglib/ProductNavigationControlMenuTag.java
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/java/com/liferay/product/navigation/taglib/servlet/taglib/ProductNavigationControlMenuTag.java
@@ -14,8 +14,12 @@
 
 package com.liferay.product.navigation.taglib.servlet.taglib;
 
+import com.liferay.application.list.display.context.logic.PanelCategoryHelper;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.product.navigation.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.taglib.util.IncludeTag;
 
@@ -75,6 +79,29 @@ public class ProductNavigationControlMenuTag extends IncludeTag {
 
 	@Override
 	protected void setAttributes(HttpServletRequest httpServletRequest) {
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		httpServletRequest.setAttribute(
+			"liferay-product-navigation:control-menu:globalMenuApp",
+			_isGlobalMenuApp(themeDisplay.getPpid()));
+	}
+
+	private boolean _isGlobalMenuApp(String ppid) {
+		if (Validator.isNull(ppid)) {
+			return false;
+		}
+
+		PanelCategoryHelper panelCategoryHelper = new PanelCategoryHelper(
+			ServletContextUtil.getPanelAppRegistry(),
+			ServletContextUtil.getPanelCategoryRegistry());
+
+		if (panelCategoryHelper.isGlobalMenuApp(ppid)) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private static final String _PAGE = "/control_menu/page.jsp";

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/page.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/page.jsp
@@ -17,6 +17,8 @@
 <%@ include file="/control_menu/init.jsp" %>
 
 <%
+boolean globalMenuApp = (boolean)request.getAttribute("liferay-product-navigation:control-menu:globalMenuApp");
+
 ProductNavigationControlMenuCategoryRegistry productNavigationControlMenuCategoryRegistry = ServletContextUtil.getProductNavigationControlMenuCategoryRegistry();
 
 List<ProductNavigationControlMenuCategory> productNavigationControlMenuCategories = productNavigationControlMenuCategoryRegistry.getProductNavigationControlMenuCategories(ProductNavigationControlMenuCategoryKeys.ROOT);
@@ -38,7 +40,7 @@ for (ProductNavigationControlMenuCategory productNavigationControlMenuCategory :
 %>
 
 <c:if test="<%= hasControlMenuEntries %>">
-	<div class="control-menu-container">
+	<div class="control-menu-container <%= globalMenuApp ? "global-menu-app" : "" %>">
 		<liferay-util:dynamic-include key="com.liferay.product.navigation.taglib#/page.jsp#pre" />
 
 		<div class="control-menu control-menu-level-1 d-print-none" data-qa-id="controlMenu" id="<portlet:namespace />ControlMenu">

--- a/modules/apps/push-notifications/push-notifications-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/push-notifications/push-notifications-web/src/main/resources/META-INF/resources/view.jsp
@@ -25,7 +25,6 @@ portletURL.setParameter("tabs1", tabs1);
 %>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems='<%=
 		new JSPNavigationItemList(pageContext) {
 			{

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_tabs.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_tabs.jsp
@@ -17,6 +17,5 @@
 <%@ include file="/init.jsp" %>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems="<%= roleDisplayContext.getEditRoleNavigationItems() %>"
 />

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -36,7 +36,6 @@ PortletURL portletURL = viewRolesManagementToolbarDisplayContext.getPortletURL()
 %>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems="<%= roleDisplayContext.getViewRoleNavigationItems(liferayPortletResponse, portletURL) %>"
 />
 

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/server.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/server.jsp
@@ -27,7 +27,6 @@
 		%>
 
 		<clay:navigation-bar
-			inverted="<%= true %>"
 			navigationItems="<%= serverDisplayContext.getServerNavigationItems() %>"
 		/>
 

--- a/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/sync/sync-web/src/main/resources/META-INF/resources/view.jsp
@@ -21,7 +21,6 @@ String tabs1 = ParamUtil.getString(request, "tabs1", "settings");
 %>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems='<%=
 		new JSPNavigationItemList(pageContext) {
 			{

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/edit_user_group_assignments.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/edit_user_group_assignments.jsp
@@ -50,22 +50,6 @@ renderResponse.setTitle(userGroup.getName());
 PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "user-groups"), homeURL.toString());
 PortalUtil.addPortletBreadcrumbEntry(request, userGroup.getName(), null);
 
-List<NavigationItem> navigationItems = new ArrayList<>();
-
-NavigationItem entriesNavigationItem = new NavigationItem();
-
-entriesNavigationItem.setActive(true);
-entriesNavigationItem.setHref(StringPool.BLANK);
-entriesNavigationItem.setLabel(LanguageUtil.get(request, "users"));
-
-navigationItems.add(entriesNavigationItem);
-%>
-
-<clay:navigation-bar
-	navigationItems="<%= navigationItems %>"
-/>
-
-<%
 EditUserGroupAssignmentsManagementToolbarDisplayContext editUserGroupAssignmentsManagementToolbarDisplayContext = new EditUserGroupAssignmentsManagementToolbarDisplayContext(request, renderRequest, renderResponse, displayStyle, "/edit_user_group_assignments.jsp");
 
 LinkedHashMap<String, Object> userParams = new LinkedHashMap<String, Object>();

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/edit_user_group_assignments.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/edit_user_group_assignments.jsp
@@ -62,7 +62,6 @@ navigationItems.add(entriesNavigationItem);
 %>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems="<%= navigationItems %>"
 />
 

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -34,22 +34,6 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "user-gr
 <liferay-ui:error exception="<%= RequiredUserGroupException.class %>" message="you-cannot-delete-user-groups-that-have-users" />
 
 <%
-List<NavigationItem> navigationItems = new ArrayList<>();
-
-NavigationItem entriesNavigationItem = new NavigationItem();
-
-entriesNavigationItem.setActive(true);
-entriesNavigationItem.setHref(StringPool.BLANK);
-entriesNavigationItem.setLabel(LanguageUtil.get(request, "user-groups"));
-
-navigationItems.add(entriesNavigationItem);
-%>
-
-<clay:navigation-bar
-	navigationItems="<%= navigationItems %>"
-/>
-
-<%
 ViewUserGroupsManagementToolbarDisplayContext viewUserGroupsManagementToolbarDisplayContext = new ViewUserGroupsManagementToolbarDisplayContext(request, renderRequest, renderResponse, displayStyle);
 
 SearchContainer searchContainer = viewUserGroupsManagementToolbarDisplayContext.getSearchContainer();

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -46,7 +46,6 @@ navigationItems.add(entriesNavigationItem);
 %>
 
 <clay:navigation-bar
-	inverted="<%= true %>"
 	navigationItems="<%= navigationItems %>"
 />
 

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -60,7 +60,6 @@ else {
 
 <c:if test="<%= !portletName.equals(UsersAdminPortletKeys.MY_ORGANIZATIONS) && !usersListView.equals(UserConstants.LIST_VIEW_TREE) %>">
 	<clay:navigation-bar
-		inverted="<%= true %>"
 		navigationItems="<%= userDisplayContext.getViewNavigationItems() %>"
 	/>
 </c:if>


### PR DESCRIPTION
As a first step to implement the new Global Menu (some kind of mega dropdown that holds all the items present in the Product Menu that are not specific to the context of the page) Echo Team developed a PoC creating a react component that uses ClayModal to show this new feature.

The purpose of this pr is to replace the markup of that Global Menu to fit with UX design, remove the use of ClayModal and show it as a mega dropdown, plus optimizing and improving the existing React component.

Steps to reproduce:
- Deploy this pr
- Deploy the [config file](https://issues.liferay.com/secure/attachment/356992/com.liferay.product.navigation.global.menu.web.internal.configuration.FFProductNavigationGlobalMenuConfiguration.config)
- Go to any site and click the Grid Icon on the right side of the top bar.

![image](https://user-images.githubusercontent.com/5803434/82534629-bb8f4980-9b45-11ea-9cee-39493eb1ea30.png)

Note: May need to deactivate jsp precompilation in order to make this pr compile.