### PR TITLE
LPS-113033 Adds deprecation notice on `liferay-ratings` AUI component

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/ratings.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/ratings.js
@@ -12,6 +12,9 @@
  * details.
  */
 
+/**
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ */
 AUI.add(
 	'liferay-ratings',
 	(A) => {


### PR DESCRIPTION
After some conversations from:

- https://github.com/diegonvs/liferay-portal/pull/25

See also [discussion of why we're not pointing to ratings taglib and the React components it uses internally as replacement](https://github.com/wincent/liferay-portal/pull/282#pullrequestreview-415532264).