### PR TITLE
LPS-113239 FIX: Clay modals cannot be closed by clicking outside, on the sides

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_modals.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/compat/components/_modals.scss
@@ -25,6 +25,12 @@
 		margin-left: auto;
 	}
 
+	// LPS-113239
+
+	.modal-md {
+		max-width: $modal-md;
+	}
+
 	// LPS-97981
 
 	@include media-breakpoint-up(sm) {


### PR DESCRIPTION
Hey @wincent, sending this over for a sanity check... also looking for @marcoscv-work input.

Just repeating myself (but avoiding you a click):

> Based on Lexicon specs there is no such thing as a modal-md size. Following the specs,
ClayModal only provides the default max width (600px) when no `size` prop is passed to
the component.
> 
> In DXP, Clay modal styles conflict with legacy YUI/AUI modals. For that reason, we
were forced to add additional styling based on modal-* classes to trump YUI's styling
based on specificity. This is the reason why we need to pass size="md" to <ClayModal>
when we want the default behaviour. Removing the size prop will cause the modal to
become left-aligned rather than centered as fixed in LPS-97981.
> 
> With this, we're also just patching the modal behaviour so modal-md gets a proper
max-width value. Once ClayModal usage is more extended than YUI's, we should be able
to revert these changes to use proper defaults and patch YUI's legacy modals instead.
