### PR TITLE
LPS-114132 Remove charset attribute from link elements according to W3C recommendations

### DIFF
--- a/modules/apps/frontend-css/frontend-css-rtl-servlet/src/main/java/com/liferay/frontend/css/rtl/servlet/internal/RTLServlet.java
+++ b/modules/apps/frontend-css/frontend-css-rtl-servlet/src/main/java/com/liferay/frontend/css/rtl/servlet/internal/RTLServlet.java
@@ -177,7 +177,7 @@ public class RTLServlet extends HttpServlet {
 
 		httpServletResponse.setContentLength(urlConnection.getContentLength());
 
-		httpServletResponse.setContentType(ContentTypes.TEXT_CSS);
+		httpServletResponse.setContentType(ContentTypes.TEXT_CSS_UTF8);
 		httpServletResponse.setStatus(HttpServletResponse.SC_OK);
 
 		StreamUtil.transfer(

--- a/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/java/com/liferay/frontend/theme/font/awesome/web/internal/servlet/taglib/FontAwesomeTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-theme/frontend-theme-font-awesome-web/src/main/java/com/liferay/frontend/theme/font/awesome/web/internal/servlet/taglib/FontAwesomeTopHeadDynamicInclude.java
@@ -65,7 +65,7 @@ public class FontAwesomeTopHeadDynamicInclude extends BaseDynamicInclude {
 			_absolutePortalURLBuilderFactory.getAbsolutePortalURLBuilder(
 				httpServletRequest);
 
-		sb.append("<link charset=\"utf-8\" data-senna-track=\"permanent\" ");
+		sb.append("<link data-senna-track=\"permanent\" ");
 		sb.append("href=\"");
 		sb.append(
 			absolutePortalURLBuilder.forModule(

--- a/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/ComboServlet.java
@@ -283,7 +283,7 @@ public class ComboServlet extends HttpServlet {
 		String contentType = ContentTypes.TEXT_JAVASCRIPT;
 
 		if (StringUtil.equalsIgnoreCase(extension, _CSS_EXTENSION)) {
-			contentType = ContentTypes.TEXT_CSS;
+			contentType = ContentTypes.TEXT_CSS_UTF8;
 		}
 
 		httpServletResponse.setContentType(contentType);

--- a/portal-impl/src/com/liferay/portal/servlet/filters/aggregate/AggregateFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/aggregate/AggregateFilter.java
@@ -428,7 +428,7 @@ public class AggregateFilter extends IgnoreModuleRequestFilter {
 					httpServletResponse.setContentType(contentType);
 				}
 				else if (resourcePath.endsWith(_CSS_EXTENSION)) {
-					httpServletResponse.setContentType(ContentTypes.TEXT_CSS);
+					httpServletResponse.setContentType(ContentTypes.TEXT_CSS_UTF8);
 				}
 				else if (resourcePath.endsWith(_JAVASCRIPT_EXTENSION)) {
 					httpServletResponse.setContentType(
@@ -450,10 +450,10 @@ public class AggregateFilter extends IgnoreModuleRequestFilter {
 				content = getCssContent(
 					httpServletRequest, httpServletResponse, resourcePath);
 
-				httpServletResponse.setContentType(ContentTypes.TEXT_CSS);
+				httpServletResponse.setContentType(ContentTypes.TEXT_CSS_UTF8);
 
 				if (!_isLegacyIe(httpServletRequest)) {
-					FileUtil.write(cacheContentTypeFile, ContentTypes.TEXT_CSS);
+					FileUtil.write(cacheContentTypeFile, ContentTypes.TEXT_CSS_UTF8);
 				}
 			}
 			else if (resourcePath.endsWith(_JAVASCRIPT_EXTENSION)) {

--- a/portal-impl/src/com/liferay/portal/servlet/filters/aggregate/AggregateFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/aggregate/AggregateFilter.java
@@ -428,7 +428,8 @@ public class AggregateFilter extends IgnoreModuleRequestFilter {
 					httpServletResponse.setContentType(contentType);
 				}
 				else if (resourcePath.endsWith(_CSS_EXTENSION)) {
-					httpServletResponse.setContentType(ContentTypes.TEXT_CSS_UTF8);
+					httpServletResponse.setContentType(
+						ContentTypes.TEXT_CSS_UTF8);
 				}
 				else if (resourcePath.endsWith(_JAVASCRIPT_EXTENSION)) {
 					httpServletResponse.setContentType(
@@ -453,7 +454,8 @@ public class AggregateFilter extends IgnoreModuleRequestFilter {
 				httpServletResponse.setContentType(ContentTypes.TEXT_CSS_UTF8);
 
 				if (!_isLegacyIe(httpServletRequest)) {
-					FileUtil.write(cacheContentTypeFile, ContentTypes.TEXT_CSS_UTF8);
+					FileUtil.write(
+						cacheContentTypeFile, ContentTypes.TEXT_CSS_UTF8);
 				}
 			}
 			else if (resourcePath.endsWith(_JAVASCRIPT_EXTENSION)) {

--- a/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSFilter.java
@@ -148,7 +148,8 @@ public class DynamicCSSFilter extends IgnoreModuleRequestFilter {
 
 				httpServletResponse.setContentType(ContentTypes.TEXT_CSS_UTF8);
 
-				FileUtil.write(cacheContentTypeFile, ContentTypes.TEXT_CSS_UTF8);
+				FileUtil.write(
+					cacheContentTypeFile, ContentTypes.TEXT_CSS_UTF8);
 			}
 			else if (originalRequestPath.endsWith(_JSP_EXTENSION)) {
 				if (_log.isInfoEnabled()) {

--- a/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/dynamiccss/DynamicCSSFilter.java
@@ -146,9 +146,9 @@ public class DynamicCSSFilter extends IgnoreModuleRequestFilter {
 				dynamicContent = DynamicCSSUtil.replaceToken(
 					servletContext, httpServletRequest, content);
 
-				httpServletResponse.setContentType(ContentTypes.TEXT_CSS);
+				httpServletResponse.setContentType(ContentTypes.TEXT_CSS_UTF8);
 
-				FileUtil.write(cacheContentTypeFile, ContentTypes.TEXT_CSS);
+				FileUtil.write(cacheContentTypeFile, ContentTypes.TEXT_CSS_UTF8);
 			}
 			else if (originalRequestPath.endsWith(_JSP_EXTENSION)) {
 				if (_log.isInfoEnabled()) {


### PR DESCRIPTION
W3C validator reports:

> The charset attribute on the link element is obsolete. Use an HTTP Content-Type header on the linked resource instead.

[W3C guidelines](https://www.w3.org/International/questions/qa-css-charset)

We actually have a `TEXT_CSS_UTF8` constant with the desired `Content-Type` string (`text/css; charset=UTF-8`) and can just use that. In fact, we used to use it. It was added in [liferay@091f945](https://github.com/liferay/liferay-portal/commit/091f945e9cf3e) (in 2007) and we stopped using it in [liferay@9296f4a](https://github.com/liferay/liferay-portal/commit/9296f4aab29a6f370c2c8820d4f12af5492a840d) (in 2012), for reasons that are non-obvious, at least based on a reading of the related LPS, [LPS-30963](https://issues.liferay.com/browse/LPS-30963). It was probably dropped by accident.