### PR TITLE
LPS-112988 Replace Global Menu markup and styles and refactor React component

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
@@ -32,8 +32,8 @@ a.control-menu-icon,
 		}
 	}
 
-	a,
-	button:not(.dropdown-item) {
+	a:not(.dropdown-item),
+	button:not(.btn-link):not(.dropdown-item):not(.nav-link) {
 		color: $control-menu-level-1-link-color;
 
 		&:focus,

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
@@ -210,6 +210,16 @@ a.control-menu-icon,
 	width: 32px;
 }
 
+.global-menu-app {
+	.control-menu-level-1 {
+		background-color: $white;
+	}
+
+	.control-menu-level-1-heading {
+		color: $black;
+	}
+}
+
 .tools-control-group {
 	flex: 1;
 	flex-wrap: wrap;

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/global_menu/global_menu.jsp
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/global_menu/global_menu.jsp
@@ -20,7 +20,7 @@
 GlobalMenuDisplayContext globalMenuDisplayContext = new GlobalMenuDisplayContext(request);
 %>
 
-<div>
+<li class="control-menu-nav-item">
 	<clay:button
 		elementClasses="lfr-portal-tooltip"
 		icon="grid"
@@ -33,4 +33,4 @@ GlobalMenuDisplayContext globalMenuDisplayContext = new GlobalMenuDisplayContext
 		data="<%= globalMenuDisplayContext.getGlobalMenuComponentData() %>"
 		module="js/GlobalMenu"
 	/>
-</div>
+</li>

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/global_menu/global_menu.jsp
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/global_menu/global_menu.jsp
@@ -25,6 +25,7 @@ GlobalMenuDisplayContext globalMenuDisplayContext = new GlobalMenuDisplayContext
 		elementClasses="lfr-portal-tooltip"
 		icon="grid"
 		monospaced="<%= true %>"
+		size="sm"
 		style="unstyled"
 		title='<%= LanguageUtil.get(request, "global-menu") %>'
 	/>

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
@@ -116,25 +116,21 @@ const AppsPanel = ({
 										<ClayButton
 											displayType="link"
 											onClick={() => {
-												Liferay.Util.selectEntity(
-													{
-														dialog: {
-															constrain: true,
-															destroyOnHide: true,
-															modal: true,
-														},
-														eventName: `${portletNamespace}selectSite`,
-														id: `${portletNamespace}selectSite`,
-														title: Liferay.Language.get(
-															'select-site-or-asset-library'
-														),
-														uri: viewAllURL,
+												Liferay.Util.openModal({
+													id: `${portletNamespace}selectSite`,
+													onSelect: (
+														selectedItem
+													) => {
+														Liferay.Util.navigate(
+															selectedItem.url
+														);
 													},
-													(event) => {
-														location.href =
-															event.url;
-													}
-												);
+													selectEventName: `${portletNamespace}selectSite`,
+													title: Liferay.Language.get(
+														'select-site-or-asset-library'
+													),
+													url: viewAllURL,
+												});
 											}}
 											small
 										>

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
@@ -31,7 +31,7 @@ const AppsPanel = ({
 
 	return (
 		<>
-			<div className="c-px-md-3 row">
+			<div className="c-px-md-4 row">
 				<ClayTabs modern>
 					{categories.map(({key, label}, index) => (
 						<ClayTabs.Item
@@ -96,6 +96,7 @@ const AppsPanel = ({
 													href={url}
 												>
 													<ClaySticker
+														className="inline-item-before"
 														inline={true}
 														size="sm"
 													>
@@ -135,6 +136,7 @@ const AppsPanel = ({
 													}
 												);
 											}}
+											small
 										>
 											{Liferay.Language.get('view-all')}
 										</ClayButton>
@@ -201,6 +203,7 @@ const GlobalMenu = ({panelAppsURL}) => {
 				onClick={handleButtonOnClick}
 				onFocus={fetchCategories}
 				onHover={fetchCategories}
+				small
 				symbol="grid"
 				title={Liferay.Language.get('global-menu')}
 			/>

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/js/GlobalMenu.js
@@ -209,7 +209,7 @@ const GlobalMenu = ({panelAppsURL}) => {
 			/>
 
 			<ul
-				className={classNames('dropdown-menu', {
+				className={classNames('c-mt-0 dropdown-menu', {
 					show: panelVisible,
 				})}
 			>


### PR DESCRIPTION
As a first step to implement the new Global Menu (some kind of mega dropdown that holds all the items present in the Product Menu that are not specific to the context of the page) Echo Team developed a PoC creating a react component that uses ClayModal to show this new feature.

The purpose of this pr is to replace the markup and some styling for that Global Menu to fit with UX design, remove the use of ClayModal and show it as a mega dropdown, plus optimizing and improving the existing React component.

At this moment, some work needs to be done and merged by Echo Team in order to see any content on the global menu, so you won't be able to watch it in action propertly.

Anyway, the steps to reproduce it, getting an empty global menu, are:

- Deploy this pr
- Deploy the [config file](https://issues.liferay.com/secure/attachment/356992/com.liferay.product.navigation.global.menu.web.internal.configuration.FFProductNavigationGlobalMenuConfiguration.config)
- Go to any site and click the Grid Icon on the right side of the top bar.

This is how it would look with some elements:

![image](https://user-images.githubusercontent.com/5803434/82586337-acd18280-9b97-11ea-86a1-af5af90129c2.png)

Previously: https://github.com/wincent/liferay-portal/pull/281