### PR TITLE
LPS-112985 Deprecate liferay-tree-view-icons AUI utility

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/tree_view_icons.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/tree_view_icons.js
@@ -12,6 +12,9 @@
  * details.
  */
 
+/**
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ */
 AUI.add(
 	'liferay-tree-view-icons',
 	(A) => {


### PR DESCRIPTION
This task is the deprecation of `liferay-tree-view-icons` utility.
As I mentioned in the ticket, this AUI utility was created as a hack when selected AUI treeview checkbox wasn’t ticked.

This doesn’t need rewrite in VanillaJS and can safely be deprecated without introducing the breaking change.