### PR TITLE
LPS-114177 Enhance error detection when resolving JS modules

### DIFF
--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/resolution/BrowserModulesMap.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/resolution/BrowserModulesMap.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.js.loader.modules.extender.internal.resolution;
+
+import com.liferay.frontend.js.loader.modules.extender.internal.resolution.adapter.JSBrowserModule;
+import com.liferay.frontend.js.loader.modules.extender.npm.JSModule;
+import com.liferay.frontend.js.loader.modules.extender.npm.NPMRegistry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Iván Zaera Avellón
+ */
+public class BrowserModulesMap {
+
+	public BrowserModulesMap(
+		BrowserModulesResolution browserModulesResolution,
+		NPMRegistry npmRegistry) {
+
+		_browserModulesResolution = browserModulesResolution;
+		_npmRegistry = npmRegistry;
+	}
+
+	public JSBrowserModule get(String resolvedModuleId) {
+		JSBrowserModule jsBrowserModule = _map.get(resolvedModuleId);
+
+		if (jsBrowserModule == null) {
+			JSModule jsModule = _npmRegistry.getResolvedJSModule(
+				resolvedModuleId);
+
+			if (jsModule != null) {
+				jsBrowserModule = new JSBrowserModule(
+					jsModule, _browserModulesResolution, _npmRegistry);
+
+				_map.put(jsBrowserModule.getName(), jsBrowserModule);
+			}
+		}
+
+		return jsBrowserModule;
+	}
+
+	private final BrowserModulesResolution _browserModulesResolution;
+	private Map<String, JSBrowserModule> _map = new HashMap<>();
+	private final NPMRegistry _npmRegistry;
+
+}

--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/resolution/BrowserModulesResolution.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/resolution/BrowserModulesResolution.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -42,6 +43,10 @@ public class BrowserModulesResolution {
 		}
 	}
 
+	public void addError(String error) {
+		_errors.add(error);
+	}
+
 	public void addProcessedModuleName(String moduleName) {
 		_processedModuleNames.add(moduleName);
 	}
@@ -62,6 +67,10 @@ public class BrowserModulesResolution {
 		sb.append(moduleName);
 
 		_explanation.add(0, sb.toString());
+	}
+
+	public void addWarning(String warning) {
+		_warnings.add(warning);
 	}
 
 	public void dedentExplanation() {
@@ -117,6 +126,14 @@ public class BrowserModulesResolution {
 			"configMap", _mappedModuleNamesMap
 		).build();
 
+		if (_errors.size() > 0) {
+			List<String> sortedErrors = new ArrayList<>(_errors);
+
+			Collections.sort(sortedErrors);
+
+			map.put("errors", sortedErrors);
+		}
+
 		if (_explanation != null) {
 			map.put("explanation", _resolvedModuleNames);
 		}
@@ -126,11 +143,20 @@ public class BrowserModulesResolution {
 		map.put("pathMap", _pathsMap);
 		map.put("resolvedModules", _resolvedModuleNames);
 
+		if (_warnings.size() > 0) {
+			List<String> sortedWarnings = new ArrayList<>(_warnings);
+
+			Collections.sort(sortedWarnings);
+
+			map.put("warnings", sortedWarnings);
+		}
+
 		return _jsonFactory.looseSerializeDeep(map);
 	}
 
 	private final Map<String, Map<String, String>> _dependenciesMap =
 		new HashMap<>();
+	private final Set<String> _errors = new HashSet<>();
 	private int _explainIndentation;
 	private List<String> _explanation;
 	private final Map<String, JSONObject> _flagsJSONObjects = new HashMap<>();
@@ -139,5 +165,6 @@ public class BrowserModulesResolution {
 	private final Map<String, String> _pathsMap = new HashMap<>();
 	private final Set<String> _processedModuleNames = new HashSet<>();
 	private final List<String> _resolvedModuleNames = new ArrayList<>();
+	private final Set<String> _warnings = new HashSet<>();
 
 }

--- a/modules/apps/frontend-js/frontend-js-web/package.json
+++ b/modules/apps/frontend-js/frontend-js-web/package.json
@@ -6,7 +6,7 @@
 		"@clayui/modal": "3.5.0",
 		"clay": "2.18.1",
 		"clay-alert": "2.21.3",
-		"liferay-amd-loader": "4.2.0",
+		"liferay-amd-loader": "4.3.0",
 		"lodash.escape": "4.0.1",
 		"lodash.groupby": "4.6.0",
 		"lodash.isequal": "4.5.0",

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -11426,10 +11426,10 @@ lie@~3.3.0:
   dependencies:
     immediate "~3.0.5"
 
-liferay-amd-loader@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/liferay-amd-loader/-/liferay-amd-loader-4.2.0.tgz#c166fa3723a7cf760deefb8e580d8892c6bf436b"
-  integrity sha512-q+b2oU6zy6gDe6uKqHPY2/L9eUjhZAVatCAC5HNrHd+tMIk+MDBSCiHmRvihoJnmPylT+RZ4gNvWxtVwIQBF/Q==
+liferay-amd-loader@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/liferay-amd-loader/-/liferay-amd-loader-4.3.0.tgz#5a6e6b94374f3d5298f637aca57220ec0b3c66ce"
+  integrity sha512-8y7jgugf3RzcmA7t4eKJaNFMKI/e2K9+UaAAuT2maDd2X047E961nELmomRfEaXA5aWIS7SvKlP/dnvfGEvxPw==
 
 liferay-ckeditor@4.13.1-liferay.5:
   version "4.13.1-liferay.5"


### PR DESCRIPTION
This PR uses a newer version of the AMD loader which has enhanced the protocol between the server and the client to be able to send warnings and errors. This way, we can make the resolution fail in the client when something is wrong in the server (a missing module or dependency, f.e.) and/or notify the user about warning (non-error conditions that may lead to a future error).

The protocol is quite simple: the server sends an errors and a warnings array in the resolution reply and the loader shows messages in the JS console with the given log level (remember that the user can change the log level in control panel). Also, if an error is sent, the loader throws an exception to fail the resolution.

I have tested that the portal works correctly after this change and have also modified a JAR file manually to remove a dependency from a package.json file and it works.