### PR TITLE
LPS-113555 Deprecate `liferay-asset-tags-selector` AUI module.

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/asset_tags_selector.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/asset_tags_selector.js
@@ -12,6 +12,9 @@
  * details.
  */
 
+/**
+ * @deprecated As of Athanasius (7.3.x), replaced by `import {AssetTagsSelector} from 'asset-taglib'`
+ */
 AUI.add(
 	'liferay-asset-tags-selector',
 	(A) => {


### PR DESCRIPTION
The `liferay-asset-tags-selector` module was migrated to React in https://issues.liferay.com/browse/LPS-100139, and all previous usages had been updated.

We already have notes in [BREAKING_CHANGES.markdown](https://github.com/liferay/liferay-portal/blob/9839677effcea2087d194c0ca29d591d5f1d8533/readme/BREAKING_CHANGES.markdown#removed-comliferayassettaglibservlettaglibsoyassettagsselectortag)