### PR TITLE
LPS-112983 Deprecate liferay-browser-selectors

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/java/com/liferay/frontend/js/aui/web/internal/servlet/AUITopHeadResources.java
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/java/com/liferay/frontend/js/aui/web/internal/servlet/AUITopHeadResources.java
@@ -81,8 +81,7 @@ public class AUITopHeadResources implements TopHeadResources {
 	}
 
 	private static final String[] _FILE_NAMES_AUI_CORE = {
-		"/aui/aui/aui.js", "/liferay/modules.js",
-		"/liferay/browser_selectors.js", "/liferay/aui_sandbox.js",
+		"/aui/aui/aui.js", "/liferay/modules.js", "/liferay/aui_sandbox.js",
 		"/aui/attribute-base/attribute-base.js",
 		"/aui/attribute-complex/attribute-complex.js",
 		"/aui/attribute-core/attribute-core.js",
@@ -150,9 +149,9 @@ public class AUITopHeadResources implements TopHeadResources {
 		"/aui/aui-node-base/aui-node-base.js",
 		"/aui/aui-node-html5/aui-node-html5.js",
 		"/aui/aui-selector/aui-selector.js", "/aui/aui-timer/aui-timer.js",
-		"/liferay/language.js", "/liferay/form.js",
-		"/liferay/form_placeholders.js", "/liferay/icon.js", "/liferay/menu.js",
-		"/liferay/notice.js", "/liferay/poller.js"
+		"/liferay/browser_selectors.js", "/liferay/language.js",
+		"/liferay/form.js", "/liferay/form_placeholders.js", "/liferay/icon.js",
+		"/liferay/menu.js", "/liferay/notice.js", "/liferay/poller.js"
 	};
 
 	private static final String[] _FILE_NAMES_AUI_PRELOAD_AUTHENTICATED = {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/layout.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/layout.js
@@ -158,8 +158,7 @@ AUI.add(
 
 					if (!firstPortletStatic || firstPortletStatic == 'end') {
 						referencePortlet = firstPortlet;
-					}
-					else {
+					} else {
 						portlets.each((item) => {
 							var isStatic = item.isStatic;
 
@@ -533,12 +532,11 @@ AUI.add(
 			});
 
 			if (layoutContainer) {
-				if (!A.UA.touch) {
+				if (!A.UA.touchEnabled) {
 					layoutContainer.once('mousemove', () => {
 						Liferay.fire('initLayout');
 					});
-				}
-				else {
+				} else {
 					Liferay.fire('initLayout');
 				}
 			}

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
@@ -274,8 +274,12 @@
 							'liferay-input-move-boxes-touch': {
 								condition: {
 									name: 'liferay-input-move-boxes-touch',
+									test(A) {
+										return (
+											A.UA.touchEnabled && !!A.UA.mobile
+										);
+									},
 									trigger: 'liferay-input-move-boxes',
-									ua: 'touchMobile',
 								},
 							},
 						},
@@ -390,8 +394,10 @@
 								condition: {
 									name:
 										'liferay-navigation-interaction-touch',
+									test(A) {
+										return A.UA.touchEnabled;
+									},
 									trigger: 'liferay-navigation-interaction',
-									ua: 'touch',
 								},
 							},
 						},

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
@@ -103,8 +103,7 @@
 						loadHTML(responseHTML);
 					},
 				});
-			}
-			else {
+			} else {
 				loadHTML(responseHTML);
 			}
 		},
@@ -173,8 +172,7 @@
 				placeHolder = A.Node.create(
 					'<div class="loading-animation" />'
 				);
-			}
-			else {
+			} else {
 				placeHolder = A.one(placeHolder);
 			}
 
@@ -239,8 +237,7 @@
 						nestedPortletOffset += nestedPortlet
 							.all('.portlet-boundary')
 							.size();
-					}
-					else if (nestedPortletIndex >= portletPosition) {
+					} else if (nestedPortletIndex >= portletPosition) {
 						return true;
 					}
 				});
@@ -273,8 +270,7 @@
 			if (!options.placeHolder && !options.plid) {
 				if (!hasStaticPortlet) {
 					container.prepend(placeHolder);
-				}
-				else {
+				} else {
 					firstPortlet.placeAfter(placeHolder);
 				}
 			}
@@ -362,8 +358,7 @@
 					if (onComplete) {
 						onComplete(portletBoundary, portletId);
 					}
-				}
-				else {
+				} else {
 					placeHolder.remove();
 				}
 
@@ -381,19 +376,16 @@
 				.then((response) => {
 					if (dataType === 'JSON') {
 						return response.json();
-					}
-					else {
+					} else {
 						return response.text();
 					}
 				})
 				.then((response) => {
 					if (dataType === 'HTML') {
 						addPortletReturn(response);
-					}
-					else if (response.refresh) {
+					} else if (response.refresh) {
 						addPortletReturn(response.portletHTML);
-					}
-					else {
+					} else {
 						Portlet._loadMarkupHeadElements(response);
 						Portlet._loadPortletFiles(response, addPortletReturn);
 					}
@@ -452,8 +444,7 @@
 				Liferay.fire('destroyPortlet', options);
 
 				Liferay.fire('closePortlet', options);
-			}
-			else {
+			} else {
 				A.config.win.focus();
 			}
 		},
@@ -512,12 +503,11 @@
 				// Functions to run on portlet load
 
 				if (canEditTitle) {
-
 					// https://github.com/yui/yui3/issues/1808
 
 					var events = 'focus';
 
-					if (!A.UA.touch) {
+					if (!A.UA.touchEnabled) {
 						events = ['focus', 'mousemove'];
 					}
 
@@ -617,8 +607,7 @@
 						placeHolder,
 						url,
 					});
-				}
-				else if (!portlet.getData('pendingRefresh')) {
+				} else if (!portlet.getData('pendingRefresh')) {
 					portlet.setData('pendingRefresh', true);
 
 					var nonAjaxableContentMessage = Lang.sub(TPL_NOT_AJAXABLE, [
@@ -648,8 +637,7 @@
 
 			if (Node && portletId instanceof Node) {
 				portletId = portletId.attr('id');
-			}
-			else if (portletId.id) {
+			} else if (portletId.id) {
 				portletId = portletId.id;
 			}
 

--- a/modules/apps/frontend-theme/frontend-theme-browser-support/bnd.bnd
+++ b/modules/apps/frontend-theme/frontend-theme-browser-support/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Frontend Theme Browser Support
+Bundle-SymbolicName: com.liferay.frontend.theme.browser.support
+Bundle-Version: 1.0.0

--- a/modules/apps/frontend-theme/frontend-theme-browser-support/build.gradle
+++ b/modules/apps/frontend-theme/frontend-theme-browser-support/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
+	compileOnly project(":core:petra:petra-string")
+}

--- a/modules/apps/frontend-theme/frontend-theme-browser-support/src/main/java/com/liferay/frontend/theme/browser/support/internal/theme/contributor/BrowserTemplateContextContributor.java
+++ b/modules/apps/frontend-theme/frontend-theme-browser-support/src/main/java/com/liferay/frontend/theme/browser/support/internal/theme/contributor/BrowserTemplateContextContributor.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.theme.browser.support.internal.theme.contributor;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
+import com.liferay.portal.kernel.template.TemplateContextContributor;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Chema Balsas
+ */
+@Component(
+	immediate = true,
+	property = "type=" + TemplateContextContributor.TYPE_THEME,
+	service = TemplateContextContributor.class
+)
+public class BrowserTemplateContextContributor
+	implements TemplateContextContributor {
+
+	@Override
+	public void prepare(
+		Map<String, Object> contextObjects,
+		HttpServletRequest httpServletRequest) {
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append(GetterUtil.getString(contextObjects.get("bodyCssClass")));
+		sb.append(StringPool.SPACE);
+		sb.append(BrowserSnifferUtil.getBrowserId(httpServletRequest));
+
+		if (BrowserSnifferUtil.isMobile(httpServletRequest)) {
+			sb.append(StringPool.SPACE);
+			sb.append("mobile");
+		}
+
+		contextObjects.put("bodyCssClass", sb.toString());
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/servlet/BrowserSnifferImpl.java
+++ b/portal-impl/src/com/liferay/portal/servlet/BrowserSnifferImpl.java
@@ -51,7 +51,10 @@ public class BrowserSnifferImpl implements BrowserSniffer {
 		BrowserMetadata browserMetadata = getBrowserMetadata(
 			httpServletRequest);
 
-		if (browserMetadata.isEdge()) {
+		if (browserMetadata.isChrome()) {
+			return BROWSER_ID_CHROME;
+		}
+		else if (browserMetadata.isEdge()) {
 			return BROWSER_ID_EDGE;
 		}
 		else if (browserMetadata.isIe()) {

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/BrowserSniffer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/BrowserSniffer.java
@@ -26,6 +26,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface BrowserSniffer {
 
+	public static final String BROWSER_ID_CHROME = "chrome";
+
 	public static final String BROWSER_ID_EDGE = "edge";
 
 	public static final String BROWSER_ID_FIREFOX = "firefox";

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/packageinfo
@@ -1,1 +1,1 @@
-version 8.2.0
+version 8.3.0

--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -57,8 +57,6 @@
 			</c:if>
 		</c:otherwise>
 	</c:choose>
-
-	Liferay.BrowserSelectors.run();
 </aui:script>
 
 <aui:script>


### PR DESCRIPTION
Hey @wincent, @julien, this is a revamp of https://github.com/wincent/liferay-portal/pull/291

**Done:**
- Inlined all references to `.touch` and `.touchMobile` replacing them with `.touchEnabled` or similars so we don't have a runtime implicit dependency on `liferay-browser-selectors`.
- Made `liferay-browser-selectors` optional
- Added a `frontend-theme-browser-support` module (because naming is hard and overmodularizing is the way!). The module implements [this suggestion](https://github.com/wincent/liferay-portal/pull/291#issuecomment-633417869) and adds the `{chrome|ie|edge|firefox|other}` and ` mobile` classes to the `body` element. This is a change from the old behaviour that was putting them in the `html` tag. I could only see `html.rtl` being used, so I figure this is fair game, but this could potentially break stuff... we can add support for `root_css_class` to be extended as well if we decide it's worth avoiding the breaking change (but that will introduce a breaking change of a different nature).

**Pending:**
- Deprecate the module (assuming we're doing so)
- The `.touch` class is not added. Usage is in 3 css spots. I'd be inclined to just look for smoke here and then figure out a better way to handle this, but I'm open to suggestions :)
- Check if additional classes need to be added or removed elsewhere

Feel free to take it from here! ;)