### PR TITLE
LPS-113569 Deprecate `liferay-language` AUI module

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/java/com/liferay/frontend/js/aui/web/internal/servlet/AUITopHeadResources.java
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/java/com/liferay/frontend/js/aui/web/internal/servlet/AUITopHeadResources.java
@@ -149,9 +149,9 @@ public class AUITopHeadResources implements TopHeadResources {
 		"/aui/aui-node-base/aui-node-base.js",
 		"/aui/aui-node-html5/aui-node-html5.js",
 		"/aui/aui-selector/aui-selector.js", "/aui/aui-timer/aui-timer.js",
-		"/liferay/browser_selectors.js", "/liferay/language.js",
-		"/liferay/form.js", "/liferay/form_placeholders.js", "/liferay/icon.js",
-		"/liferay/menu.js", "/liferay/notice.js", "/liferay/poller.js"
+		"/liferay/browser_selectors.js", "/liferay/form.js",
+		"/liferay/form_placeholders.js", "/liferay/icon.js", "/liferay/menu.js",
+		"/liferay/notice.js", "/liferay/poller.js"
 	};
 
 	private static final String[] _FILE_NAMES_AUI_PRELOAD_AUTHENTICATED = {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/language.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/language.js
@@ -15,4 +15,3 @@
 /**
  * @deprecated As of Athanasius (7.3.x), replaced by `Liferay.Language`.
  */
-(function () {})();

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/language.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/language.js
@@ -12,52 +12,7 @@
  * details.
  */
 
-(function (A, Liferay) {
-	var Language = {};
-
-	Language.get = function (key) {
-		return key;
-	};
-
-	A.use('io-base', (A) => {
-		Language.get = A.cached((key, extraParams) => {
-			var url =
-				themeDisplay.getPathContext() +
-				'/language/' +
-				themeDisplay.getLanguageId() +
-				'/' +
-				key +
-				'/';
-
-			if (extraParams) {
-				if (typeof extraParams == 'string') {
-					url += extraParams;
-				}
-				else if (Array.isArray(extraParams)) {
-					url += extraParams.join('/');
-				}
-			}
-
-			var headers = {
-				'X-CSRF-Token': Liferay.authToken,
-			};
-
-			var value = '';
-
-			A.io(url, {
-				headers,
-				method: 'GET',
-				on: {
-					complete(i, o) {
-						value = o.responseText;
-					},
-				},
-				sync: true,
-			});
-
-			return value;
-		});
-	});
-
-	Liferay.Language = Language;
-})(AUI(), Liferay);
+/**
+ * @deprecated As of Athanasius (7.3.x), replaced by `Liferay.Language`.
+ */
+(function () {})();

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/available_languages.jsp
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/available_languages.jsp
@@ -46,6 +46,6 @@ AUI.add(
 	},
 	'',
 	{
-		requires: ['liferay-language']
+		requires: []
 	}
 );

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/global.es.js
@@ -96,6 +96,10 @@ Liferay.Address = {
  */
 Liferay.DynamicSelect = DynamicSelect;
 
+Liferay.Language = {
+	get: (key) => key,
+};
+
 Liferay.LayoutExporter = {
 	all: hideLayoutPane,
 	details: toggleLayoutDetails,


### PR DESCRIPTION
`Liferay.Language.get` is replaced by the [language filter][1] and we also want to remove the AUI dependency, so in this change, we migrate the `Liferay.Language.get` function to `frontend-js-web`.

Note that the migrated version is dumbed down to just return the key: it does not preserve the dubious fallback behavior of the old implementation, that used a deprecated *synchronous* request to the server to fetch the value, which would produce a console warning, and very likely end up returning the key anyway (unless the corresponding value happened to be in the kernel); in short, the old implementation only wallpapered over a real problem (failure of the filter to do its actual job).

Additional notes:

The [`portal-available-languages`][2] AUI module defines 2 more functions on the global `Liferay.Language` object.

[1]: https://github.com/liferay/liferay-portal/blob/9839677effcea2087d194c0ca29d591d5f1d8533/portal-impl/src/portal.properties#L9796-L9807
[2]: https://github.com/liferay/liferay-portal/blob/a0bfd3552193bb33687ef3677fe4879447e04d6a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/available_languages.jsp
