### PR TITLE
LPS-113598 Deprecate `Liferay.Widget`

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/widget.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/widget.js
@@ -14,6 +14,9 @@
 
 window.Liferay = window.Liferay || {};
 
+/**
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ */
 Liferay.Widget = function (options) {
 	options = options || {};
 


### PR DESCRIPTION
There are currently no usages of `Liferay.Widget` so mark this file as deprecated.

Confirmed this by searching with `git grep -w Liferay.Widget` and `git grep -w liferay-widget`, and used `git log -G'\bLiferay.Widget\b' -p` to determine that the last actual usage was removed in [cad2339833](https://github.com/liferay/liferay-portal/commit/cad233983363608989d1bfc3622775dc26381206).