### PR TITLE
LPS-113578 Deprecate `module.js`

### DIFF
--- a/modules/apps/analytics/.gitrepo
+++ b/modules/apps/analytics/.gitrepo
@@ -1,8 +1,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 1d9e489cf988791d5b742d5116afac25b49f660f
+	commit = abb5735a9aa2598bd3753f17fae39d63dab54016
 	mergebuttonmergecommits = false
 	mode = push
-	parent = d3472c7de96de300b4c31d04610ba2ff2ec54d61
+	parent = d7986620aaf95241c1afc08d450666220bf24a9d
 	remote = git@github.com:liferay/com-liferay-analytics.git

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/modules.js
@@ -12,6 +12,9 @@
  * details.
  */
 
+/**
+ * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ */
 (function () {
 	var LiferayAUI = Liferay.AUI;
 


### PR DESCRIPTION
This file contains the configuration for AUI/YUI modules.

There are no usages of this file except that it's referenced in [AUITopHeadResources.java](https://github.com/liferay/liferay-portal/blob/9617f95b39dbb47f032785f08b71932038e1bb9e/modules/apps/frontend-js/frontend-js-aui-web/src/main/java/com/liferay/frontend/js/aui/web/internal/servlet/AUITopHeadResources.java#L84).

We can deprecate this file because, as we work through [LPS-98564](https://issues.liferay.com/browse/LPS-98564) ("Remove AUI / YUI from Liferay Portal"), eventually all the AUI modules will be deprecated or migrated.

More information about YUI's configuration can be found [here](https://yuilibrary.com/yui/docs/api/classes/config.html).

Used the following commands to find usages or references:

```
git grep -w modules.js
```

Which showed:

```
modules/apps/frontend-js/frontend-js-aui-web/src/main/java/com/liferay/frontend/js/aui/web/internal/servlet/AUITopHeadResources.java:
"/aui/aui/aui.js", "/liferay/modules.js", "/liferay/aui_sandbox.js",
```