### PR TITLE
LPS-114186 Migrate AUI tree-view in asset-taglib to React

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetCategoriesNavigationDisplayContext.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetCategoriesNavigationDisplayContext.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.taglib.internal.display.context;
+
+import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryServiceUtil;
+import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.portlet.PortletURL;
+import javax.portlet.RenderResponse;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class AssetCategoriesNavigationDisplayContext {
+
+	public AssetCategoriesNavigationDisplayContext(
+		HttpServletRequest httpServletRequest, RenderResponse renderResponse) {
+
+		_httpServletRequest = httpServletRequest;
+		_renderResponse = renderResponse;
+
+		_themeDisplay = (ThemeDisplay)_httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		_vocabularyIds = (long[])httpServletRequest.getAttribute(
+			"liferay-asset:asset-tags-navigation:vocabularyIds");
+	}
+
+	public String buildVocabularyNavigation(AssetVocabulary vocabulary)
+		throws Exception {
+
+		List<AssetCategory> categories =
+			AssetCategoryServiceUtil.getVocabularyRootCategories(
+				vocabulary.getGroupId(), vocabulary.getVocabularyId(),
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS, null);
+
+		if (categories.isEmpty()) {
+			return null;
+		}
+
+		StringBundler sb = new StringBundler();
+
+		sb.append("<div class=\"lfr-asset-category-list-container\">");
+		sb.append("<ul class=\"lfr-asset-category-list\">");
+
+		_buildCategoriesNavigation(categories, sb);
+
+		sb.append("</ul></div>");
+
+		return sb.toString();
+	}
+
+	public long getCategoryId() {
+		if (_categoryId != null) {
+			return _categoryId;
+		}
+
+		_categoryId = ParamUtil.getLong(_httpServletRequest, "categoryId");
+
+		return _categoryId;
+	}
+
+	public List<AssetVocabulary> getVocabularies() throws PortalException {
+		if (_vocabularies != null) {
+			return _vocabularies;
+		}
+
+		if (_vocabularyIds == null) {
+			_vocabularies = AssetVocabularyServiceUtil.getGroupVocabularies(
+				PortalUtil.getCurrentAndAncestorSiteGroupIds(
+					_themeDisplay.getScopeGroupId()));
+
+			return _vocabularies;
+		}
+
+		List<AssetVocabulary> vocabularies = new ArrayList<>();
+
+		for (long vocabularyId : _vocabularyIds) {
+			AssetVocabulary vocabulary =
+				AssetVocabularyServiceUtil.fetchVocabulary(vocabularyId);
+
+			if (vocabulary != null) {
+				vocabularies.add(vocabulary);
+			}
+		}
+
+		_vocabularies = vocabularies;
+
+		return _vocabularies;
+	}
+
+	private void _buildCategoriesNavigation(
+			List<AssetCategory> categories, StringBundler sb)
+		throws Exception {
+
+		PortletURL portletURL = _renderResponse.createRenderURL();
+
+		portletURL.setParameter("categoryId", StringPool.BLANK);
+
+		String originalPortletURLString = portletURL.toString();
+
+		for (AssetCategory category : categories) {
+			List<AssetCategory> categoriesChildren =
+				AssetCategoryServiceUtil.getChildCategories(
+					category.getCategoryId());
+
+			sb.append("<li class=\"tree-node\"><span>");
+
+			if (getCategoryId() == category.getCategoryId()) {
+				sb.append("<a class=\"tag-selected\" href=\"");
+				sb.append(HtmlUtil.escape(originalPortletURLString));
+			}
+			else {
+				portletURL.setParameter(
+					"categoryId", String.valueOf(category.getCategoryId()));
+
+				sb.append("<a href=\"");
+				sb.append(HtmlUtil.escape(portletURL.toString()));
+			}
+
+			sb.append("\">");
+			sb.append(
+				HtmlUtil.escape(category.getTitle(_themeDisplay.getLocale())));
+			sb.append("</a>");
+			sb.append("</span>");
+
+			if (!categoriesChildren.isEmpty()) {
+				sb.append("<ul>");
+
+				_buildCategoriesNavigation(categoriesChildren, sb);
+
+				sb.append("</ul>");
+			}
+
+			sb.append("</li>");
+		}
+	}
+
+	private Long _categoryId;
+	private final HttpServletRequest _httpServletRequest;
+	private final RenderResponse _renderResponse;
+	private final ThemeDisplay _themeDisplay;
+	private List<AssetVocabulary> _vocabularies;
+	private long[] _vocabularyIds;
+
+}

--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetCategoriesNavigationDisplayContext.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetCategoriesNavigationDisplayContext.java
@@ -193,6 +193,8 @@ public class AssetCategoriesNavigationDisplayContext {
 		).put(
 			"children", _getChildCategoriesJSONArray(category.getCategoryId())
 		).put(
+			"id", category.getCategoryId()
+		).put(
 			"name",
 			HtmlUtil.escape(category.getTitle(_themeDisplay.getLocale()))
 		).put(

--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetCategoriesNavigationDisplayContext.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetCategoriesNavigationDisplayContext.java
@@ -199,6 +199,8 @@ public class AssetCategoriesNavigationDisplayContext {
 			HtmlUtil.escape(category.getTitle(_themeDisplay.getLocale()))
 		).put(
 			"url", _getPortletURL(category.getCategoryId())
+		).put(
+			"vocabularyId", category.getVocabularyId()
 		);
 	}
 

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/init.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/init.jsp
@@ -16,7 +16,7 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+<%@ taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
@@ -24,11 +24,13 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 page import="com.liferay.asset.taglib.internal.display.context.AssetCategoriesNavigationDisplayContext" %><%@
 page import="com.liferay.asset.taglib.internal.util.AssetCategoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
-page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
+page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.JavaConstants" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.taglib.aui.AUIUtil" %>
+
+<%@ page import="java.util.Map" %>
 
 <%@ page import="javax.portlet.PortletRequest" %><%@
 page import="javax.portlet.PortletResponse" %>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/init.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/init.jsp
@@ -20,31 +20,18 @@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.asset.kernel.model.AssetCategory" %><%@
-page import="com.liferay.asset.kernel.model.AssetVocabulary" %><%@
-page import="com.liferay.asset.kernel.service.AssetCategoryServiceUtil" %><%@
-page import="com.liferay.asset.kernel.service.AssetVocabularyServiceUtil" %><%@
+<%@ page import="com.liferay.asset.kernel.model.AssetVocabulary" %><%@
+page import="com.liferay.asset.taglib.internal.display.context.AssetCategoriesNavigationDisplayContext" %><%@
 page import="com.liferay.asset.taglib.internal.util.AssetCategoryUtil" %><%@
-page import="com.liferay.petra.string.StringBundler" %><%@
-page import="com.liferay.petra.string.StringPool" %><%@
-page import="com.liferay.portal.kernel.dao.orm.QueryUtil" %><%@
-page import="com.liferay.portal.kernel.exception.PortalException" %><%@
-page import="com.liferay.portal.kernel.theme.ThemeDisplay" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.JavaConstants" %><%@
-page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
-page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.taglib.aui.AUIUtil" %>
 
-<%@ page import="java.util.ArrayList" %><%@
-page import="java.util.List" %>
-
 <%@ page import="javax.portlet.PortletRequest" %><%@
-page import="javax.portlet.PortletResponse" %><%@
-page import="javax.portlet.PortletURL" %>
+page import="javax.portlet.PortletResponse" %>
 
 <liferay-theme:defineObjects />
 

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {Treeview} from 'frontend-js-components-web';
+import React from 'react';
+
+const AssetCategoriesNavigationTreeView = ({categories, namespace}) => {
+	return (
+		<div
+			className="categories-tree container-fluid-1280"
+			id={`${namespace}categoriesContainer`}
+		>
+			<Treeview NodeComponent={Treeview.Card} nodes={categories} />
+		</div>
+	);
+};
+
+export default AssetCategoriesNavigationTreeView;

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
@@ -16,25 +16,19 @@ import {Treeview} from 'frontend-js-components-web';
 import React from 'react';
 
 function buildNodes(vocabularies, categories) {
-	const nodes = [];
-
-	vocabularies.forEach((vocabulary) => {
-		const child = {
-			...vocabulary,
-			children: [],
-			id: vocabulary.vocabularyId,
-		};
-
-		categories.forEach((category) => {
-			if (category.vocabularyId === child.id) {
-				child.children.push(category);
-			}
-		});
-
-		nodes.push(child);
-	});
-
-	return nodes;
+	return vocabularies.map((vocabulary) => ({
+		...vocabulary,
+		children: categories
+			.map((category) => {
+				if (category.vocabularyId === vocabulary.vocabularyId) {
+					return {
+						...category,
+					};
+				}
+			})
+			.filter(Boolean),
+		id: vocabulary.vocabularyId,
+	}));
 }
 
 const AssetCategoriesNavigationTreeView = ({

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
@@ -15,13 +15,41 @@
 import {Treeview} from 'frontend-js-components-web';
 import React from 'react';
 
-const AssetCategoriesNavigationTreeView = ({categories, namespace}) => {
+function buildNodes(vocabularies, categories) {
+	const nodes = [];
+
+	vocabularies.forEach((vocabulary) => {
+		const child = {
+			...vocabulary,
+			children: [],
+			id: vocabulary.vocabularyId,
+		};
+
+		categories.forEach((category) => {
+			if (category.vocabularyId === child.id) {
+				child.children.push(category);
+			}
+		});
+
+		nodes.push(child);
+	});
+
+	return nodes;
+}
+
+const AssetCategoriesNavigationTreeView = ({
+	categories,
+	namespace,
+	vocabularies,
+}) => {
+	const nodes = buildNodes(vocabularies, categories);
+
 	return (
 		<div
 			className="categories-tree container-fluid-1280"
 			id={`${namespace}categoriesContainer`}
 		>
-			<Treeview NodeComponent={Treeview.Card} nodes={categories} />
+			<Treeview NodeComponent={Treeview.Card} nodes={nodes} />
 		</div>
 	);
 };

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
@@ -18,15 +18,9 @@ import React from 'react';
 function buildNodes(vocabularies, categories) {
 	return vocabularies.map((vocabulary) => ({
 		...vocabulary,
-		children: categories
-			.map((category) => {
-				if (category.vocabularyId === vocabulary.vocabularyId) {
-					return {
-						...category,
-					};
-				}
-			})
-			.filter(Boolean),
+		children: categories.filter((category) => {
+			return category.vocabularyId === vocabulary.vocabularyId;
+		}),
 		id: vocabulary.vocabularyId,
 	}));
 }

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
@@ -31,21 +31,10 @@ function buildNodes(vocabularies, categories) {
 	}));
 }
 
-const AssetCategoriesNavigationTreeView = ({
-	categories,
-	namespace,
-	vocabularies,
-}) => {
+const AssetCategoriesNavigationTreeView = ({categories, vocabularies}) => {
 	const nodes = buildNodes(vocabularies, categories);
 
-	return (
-		<div
-			className="categories-tree container-fluid-1280"
-			id={`${namespace}categoriesContainer`}
-		>
-			<Treeview NodeComponent={Treeview.Card} nodes={nodes} />
-		</div>
-	);
+	return <Treeview NodeComponent={Treeview.Card} nodes={nodes} />;
 };
 
 export default AssetCategoriesNavigationTreeView;

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/page.jsp
@@ -63,6 +63,8 @@ Map<String, Object> data = HashMapBuilder.<String, Object>put(
 	"categories", assetCategoriesNavigationDisplayContext.getCategoriesJSONArray()
 ).put(
 	"namespace", namespace
+).put(
+	"vocabularies", assetCategoriesNavigationDisplayContext.getVocabularies()
 ).build();
 %>
 

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/page.jsp
@@ -68,7 +68,7 @@ Map<String, Object> data = HashMapBuilder.<String, Object>put(
 ).build();
 %>
 
-<div>
+<div class="categories-tree container-fluid-1280" id="<portlet:namespace />categoriesContainer">
 	<react:component
 		data="<%= data %>"
 		module="asset_categories_navigation/js/AssetCategoriesNavigationTreeView"

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/page.jsp
@@ -35,19 +35,6 @@ boolean hidePortletWhenEmpty = GetterUtil.getBoolean((String)request.getAttribut
 
 		if (Validator.isNotNull(vocabularyNavigation)) {
 			hidePortletWhenEmpty = false;
-	%>
-
-			<liferay-ui:panel
-				collapsible="<%= false %>"
-				extended="<%= true %>"
-				markupView="lexicon"
-				persistState="<%= true %>"
-				title="<%= HtmlUtil.escape(vocabulary.getUnambiguousTitle(assetCategoriesNavigationDisplayContext.getVocabularies(), themeDisplay.getSiteGroupId(), themeDisplay.getLocale())) %>"
-			>
-				<%= vocabularyNavigation %>
-			</liferay-ui:panel>
-
-	<%
 		}
 	}
 	%>
@@ -71,32 +58,17 @@ if (assetCategoriesNavigationDisplayContext.getCategoryId() > 0) {
 }
 %>
 
-<aui:script use="aui-tree-view">
-	var treeViews = A.all(
-		'#<%= namespace %>taglibAssetCategoriesNavigationPanel .lfr-asset-category-list-container'
-	);
+<%
+Map<String, Object> data = HashMapBuilder.<String, Object>put(
+	"categories", assetCategoriesNavigationDisplayContext.getCategoriesJSONArray()
+).put(
+	"namespace", namespace
+).build();
+%>
 
-	treeViews.each(function (item, index, collection) {
-		var assetCategoryList = item.one('.lfr-asset-category-list');
-
-		var treeView = new A.TreeView({
-			boundingBox: item,
-			contentBox: assetCategoryList,
-			type: 'normal',
-		}).render();
-
-		var selected = assetCategoryList.one('.tree-node .tag-selected');
-
-		if (selected) {
-			var selectedChild = treeView.getNodeByChild(selected);
-
-			selectedChild.expand();
-
-			selectedChild.eachParent(function (node) {
-				if (node instanceof A.TreeNode) {
-					node.expand();
-				}
-			});
-		}
-	});
-</aui:script>
+<div>
+	<react:component
+		data="<%= data %>"
+		module="asset_categories_navigation/js/AssetCategoriesNavigationTreeView"
+	/>
+</div>


### PR DESCRIPTION
Hey @wincent ,

This PR is follow up on 
- https://github.com/julien/liferay-portal/pull/284
- https://github.com/julien/liferay-portal/pull/285
- https://github.com/mateomustapic/liferay-portal/pull/9
- https://github.com/mateomustapic/liferay-portal/pull/10

This PR is a work on migration of `AUI tree-view` to `React` in `asset-taglib` module.
The old aui tree-view implementation had completely different logic than React TreeView requires, so I Eudaldo created new Java classes which can now be used in new implementation.

I used the `<react:component>` tag and included React component in the `jsp` where old tree-view was located, and I additionally cleaned up unnecessary `jsp` and AUI code which was used in old implementation.
Additionally, Julien made modifications to react component for passing categories and vocabularies to `AssetCategoriesNavigationTreeView` component.

To test these changes :

1. Navigate to Categorization / Categories
2. Create some categories in Vocabularies list for test
3. Create a widget page (Site Builder/Pages new Blank Page)
4. Add the portlet categories navigation to a page

Now the tree view should be visible on created page.

If you need anything else to test this, please tell me.

I am sending screenshots in the next comments