### PR TITLE
LPS-113561 Remove `Liferay.provide` in `account-admin-web`

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
@@ -173,7 +173,7 @@ List<String> domains = accountEntryDisplay.getDomains();
 		});
 	}
 
-	Liferay.provide(window, 'addRow', function (domain) {
+	window.addRow = function (domain) {
 		var rowColumns = [];
 
 		rowColumns.push(Liferay.Util.escape(domain));
@@ -186,5 +186,5 @@ List<String> domains = accountEntryDisplay.getDomains();
 		searchContainer.addRow(rowColumns, domain);
 
 		domains.push(domain);
-	});
+	};
 </aui:script>

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
@@ -160,8 +160,21 @@ List<String> domains = accountEntryDisplay.getDomains();
 					var newDomains = event.data.split(',');
 
 					newDomains.forEach(function (domain) {
+						domain = domain.trim();
+
 						if (!domains.includes(domain)) {
-							addRow(domain.trim());
+							var rowColumns = [];
+
+							rowColumns.push(Liferay.Util.escape(domain));
+							rowColumns.push(
+								'<a class="modify-link pull-right" data-rowId="' +
+									domain +
+									'" href="javascript:;"><%= UnicodeFormatter.toString(removeDomainIcon) %></a>'
+							);
+
+							searchContainer.addRow(rowColumns, domain);
+
+							domains.push(domain);
 						}
 					});
 
@@ -172,19 +185,4 @@ List<String> domains = accountEntryDisplay.getDomains();
 			);
 		});
 	}
-
-	window.addRow = function (domain) {
-		var rowColumns = [];
-
-		rowColumns.push(Liferay.Util.escape(domain));
-		rowColumns.push(
-			'<a class="modify-link pull-right" data-rowId="' +
-				domain +
-				'" href="javascript:;"><%= UnicodeFormatter.toString(removeDomainIcon) %></a>'
-		);
-
-		searchContainer.addRow(rowColumns, domain);
-
-		domains.push(domain);
-	};
 </aui:script>


### PR DESCRIPTION
As part of [LPS-113561](https://issues.liferay.com/browse/LPS-113561), we're eventually want to deprecate `Liferay.provide`, so here we're updating a simple usage: in this case the `addRow` function didn't depend on any AUI modules, so we can just declare it on the `window` object without changing the behavior. And because there are no external callers, we can avoid the pollution entirely and just inline the operation. In doing this, we fixed a bug that would allow the same domain to be added multiple times.

To test this change

- From the global menu select the "Control Panel" tab, and navigate to "Accounts".
- Click on the "+" button to create a new account
- Optionally add a name for this account
- Scroll down and find the "Valid Domains" section
- Click on the "Add" button to add a domain
- Enter a valid domain name, e.g. "liferay.com"
- Click on the "Save" button
- The "liferay.com" domain should be added to the list of "Valid Domains"

![account-admin-web](https://user-images.githubusercontent.com/5572/83873372-fd1e1800-a733-11ea-817a-4e10e9c04ccd.png)