### PR TITLE
LPS-113561 Remove the unnecssary `liferay-util-window` dependency

### DIFF
--- a/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/dynamic_include/bottom.jsp
+++ b/modules/apps/sharing/sharing-web/src/main/resources/META-INF/resources/dynamic_include/bottom.jsp
@@ -62,7 +62,7 @@ sharingURL.setWindowState(LiferayWindowState.POP_UP);
 
 			showDialog(sharingURL.toString(), title);
 		},
-		['liferay-util-window']
+		[]
 	);
 
 	Liferay.provide(
@@ -84,7 +84,7 @@ sharingURL.setWindowState(LiferayWindowState.POP_UP);
 				'<%= LanguageUtil.get(resourceBundle, "manage-collaborators") %>'
 			);
 		},
-		['liferay-util-window']
+		[]
 	);
 
 	Liferay.Sharing = Sharing;


### PR DESCRIPTION
As part of [LPS-113561](https://issues.liferay.com/browse/LPS-113561), we're eventually going to deprecate `Liferay.provide`.

In this change we have removed the `liferay-util-window` dependency from the [`Liferay.Sharing.share`](https://git.io/Jf1Ze) and [`Liferay.Sharing.manageCollaborators`](https://git.io/Jf1Zf) functions, because  `Liferay.Util.Window` is declared and available as a global, we don't need to declare it as a dependency.

To test these changes

For `Liferay.Sharing.share`:

- Navigate to "Content and Data > Documents and Media"
- Updload a file (an image or a text file will do)
- Once uploaded, click on the contextual menu and choose "Share"
- A modal window should open, letting you share this document with another user
- Enter the user's email address and click on the "Share" button
- A notification should be displayed letting you know the item has been shared

For `Liferay.Sharing.manageCollaborators`:

- Navigate to "Content and Data > Blogs"
- Create a new "Blog Entry"
- Click on the "Publish button"
- Click on the contextual menu next to your blog entry and choose "Manage Collaborators"
- A modal window should open letting you change your collaborators' permissions (Update, Comment or View)
- Choose a different option, and click on the "Save Button"
- A notification should be displayed letting you know the permissions have changed