### PR TITLE
LPS-114108 Add transitions and modal-like styles to Global Apps Menu

### DIFF
--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/css/GlobalMenu.scss
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/css/GlobalMenu.scss
@@ -1,7 +1,26 @@
 $control-menu-height: 56px;
 $tab-header-height: 38px;
 
-.global-menu__tab-pane {
-	max-height: calc(100vh - #{$control-menu-height + $tab-header-height});
-	overflow-y: auto;
+.global-apps-menu {
+	.tab-pane {
+		max-height: calc(100vh - #{$control-menu-height + $tab-header-height});
+		overflow-y: auto;
+	}
+}
+
+.global-apps-menu-modal {
+	.modal-full {
+		margin-top: 0;
+		max-width: initial;
+		width: 100%;
+
+		.modal-body {
+			padding-top: 12px;
+		}
+
+		.modal-content {
+			border-radius: 0;
+			box-shadow: none;
+		}
+	}
 }

--- a/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/css/GlobalMenu.scss
+++ b/modules/apps/product-navigation/product-navigation-global-menu-web/src/main/resources/META-INF/resources/css/GlobalMenu.scss
@@ -1,26 +1,21 @@
 $control-menu-height: 56px;
 $tab-header-height: 38px;
 
-.global-apps-menu {
-	.tab-pane {
-		max-height: calc(100vh - #{$control-menu-height + $tab-header-height});
-		overflow-y: auto;
-	}
+.global-apps-menu .tab-pane {
+	max-height: calc(100vh - #{$control-menu-height + $tab-header-height});
+	overflow-y: auto;
 }
 
-.global-apps-menu-modal {
-	.modal-full {
-		margin-top: 0;
-		max-width: initial;
-		width: 100%;
+.global-apps-menu-modal .modal-full {
+	margin-top: 0;
+	width: 100%;
 
-		.modal-body {
-			padding-top: 12px;
-		}
+	.modal-body {
+		padding-top: 12px;
+	}
 
-		.modal-content {
-			border-radius: 0;
-			box-shadow: none;
-		}
+	.modal-content {
+		border-radius: 0;
+		box-shadow: none;
 	}
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/globalnavigation/GlobalMenuHelper.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/globalnavigation/GlobalMenuHelper.macro
@@ -1,11 +1,11 @@
 definition {
 
 	macro closeGlobalMenu {
-		if (IsElementPresent(locator1 = "GlobalMenu#GLOBAL_MENU_SHOWN")) {
+		if (IsElementPresent(locator1 = "GlobalMenu#GLOBAL_MENU")) {
 			Click(locator1 = "GlobalMenu#TOGGLE");
 		}
 
-		AssertElementPresent(locator1 = "GlobalMenu#GLOBAL_MENU_HIDDEN");
+		WaitForElementNotPresent(locator1 = "GlobalMenu#GLOBAL_MENU");
 	}
 
 	macro gotoPortlet {
@@ -17,11 +17,11 @@ definition {
 	}
 
 	macro openGlobalMenu {
-		if (IsElementPresent(locator1 = "GlobalMenu#GLOBAL_MENU_HIDDEN")) {
+		if (IsElementNotPresent(locator1 = "GlobalMenu#GLOBAL_MENU")) {
 			Click(locator1 = "GlobalMenu#TOGGLE");
 		}
 
-		AssertElementPresent(locator1 = "GlobalMenu#GLOBAL_MENU_SHOWN");
+		WaitForElementPresent(locator1 = "GlobalMenu#GLOBAL_MENU");
 	}
 
 	macro openWorkspace {

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/globalmenu/GlobalMenu.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/globalmenu/GlobalMenu.path
@@ -14,13 +14,8 @@
 	<td></td>
 </tr>
 <tr>
-	<td>GLOBAL_MENU_HIDDEN</td>
-	<td>//div[contains(@class,'dropdown-global-app')]/ul[contains(@class,'dropdown-menu') and not(contains(@class,'show'))]</td>
-	<td></td>
-</tr>
-<tr>
-	<td>GLOBAL_MENU_SHOWN</td>
-	<td>//div[contains(@class,'dropdown-global-app')]/ul[contains(@class,'dropdown-menu') and contains(@class,'show')]</td>
+	<td>GLOBAL_MENU</td>
+	<td>//div[contains(@class,'global-apps-menu-modal')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
Adding styles and changing markup to implement transitions and new styles for the global apps menu.

- Using ClayModal instead dropdown
- Adding custom styles to make ClayModal real full-size and fit with the requirements

How to test it:

- Click on the grid icon on the right side of the Control Menu. That opens the menu.
- Click on the X or outside the menu to close it.

![Jun-08-2020 16-50-47](https://user-images.githubusercontent.com/5803434/84044744-3f4f8f80-a9a8-11ea-9453-8acc192b3676.gif)
