### PR TITLE
LPS-115073 Fixed header does not show in legacy permission modals

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
@@ -155,8 +155,6 @@ AUI.add(
 							event.details[0].dialog = modal;
 
 							if (event.doc) {
-								Util.afterIframeLoaded(event);
-
 								var modalUtil = event.win.Liferay.Util;
 
 								modalUtil.Window._opener = modal._opener;
@@ -165,6 +163,12 @@ AUI.add(
 							}
 
 							var iframeNode = modal.iframe.node;
+
+							var iframeElement = iframeNode.getDOM();
+
+							iframeElement.onload = function () {
+								Util.afterIframeLoaded(event);
+							};
 
 							iframeNode.focus();
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util_window.js
@@ -154,21 +154,21 @@ AUI.add(
 							event.dialog = modal;
 							event.details[0].dialog = modal;
 
+							var iframeNode = modal.iframe.node;
+
+							var iframeElement = iframeNode.getDOM();
+
 							if (event.doc) {
 								var modalUtil = event.win.Liferay.Util;
 
 								modalUtil.Window._opener = modal._opener;
 
 								modalUtil.Window._name = id;
+
+								iframeElement.onload = function () {
+									Util.afterIframeLoaded(event);
+								};
 							}
-
-							var iframeNode = modal.iframe.node;
-
-							var iframeElement = iframeNode.getDOM();
-
-							iframeElement.onload = function () {
-								Util.afterIframeLoaded(event);
-							};
 
 							iframeNode.focus();
 


### PR DESCRIPTION
Hey @wincent ,

This is technically a regression bug, caused by https://github.com/brianchandotcom/liferay-portal/pull/88948/commits/20bfae4195144950f57566b56493ee3743477ff1. More accurately, we exposed an ancient bug, where `afterIframeLoaded` util executed long before iframe loaded.

Test Plan:
1. Open one of the legacy permission modals. For example, Content & Data >  Bookmarks > Folder item > Permissions.
1. Reduce browser height so that table overflows.
1. Scroll down
- before the fix: fixed header does not appear
- after the fix: fixed header appears and behaves correctly

![screen](https://user-images.githubusercontent.com/5435511/84050552-2b0e9100-a9ae-11ea-9889-8c57ed096461.png)

Please review the code.

Thank you!

/cc @jbalsas