### PR TITLE
LPS-115139 Make sure polyfills are loaded before used

### DIFF
--- a/modules/apps/frontend-compatibility/frontend-compatibility-ie/src/main/java/com/liferay/frontend/compatibility/ie/internal/servlet/taglib/IETopHeadDynamicInclude.java
+++ b/modules/apps/frontend-compatibility/frontend-compatibility-ie/src/main/java/com/liferay/frontend/compatibility/ie/internal/servlet/taglib/IETopHeadDynamicInclude.java
@@ -83,7 +83,7 @@ public class IETopHeadDynamicInclude extends BaseDynamicInclude {
 	@Override
 	public void register(DynamicIncludeRegistry dynamicIncludeRegistry) {
 		dynamicIncludeRegistry.register(
-			"/html/common/themes/top_head.jsp#post");
+			"/html/common/themes/top_head.jsp#pre");
 	}
 
 	@Activate

--- a/modules/apps/frontend-compatibility/frontend-compatibility-ie/src/main/java/com/liferay/frontend/compatibility/ie/internal/servlet/taglib/IETopHeadDynamicInclude.java
+++ b/modules/apps/frontend-compatibility/frontend-compatibility-ie/src/main/java/com/liferay/frontend/compatibility/ie/internal/servlet/taglib/IETopHeadDynamicInclude.java
@@ -82,8 +82,7 @@ public class IETopHeadDynamicInclude extends BaseDynamicInclude {
 
 	@Override
 	public void register(DynamicIncludeRegistry dynamicIncludeRegistry) {
-		dynamicIncludeRegistry.register(
-			"/html/common/themes/top_head.jsp#pre");
+		dynamicIncludeRegistry.register("/html/common/themes/top_head.jsp#pre");
 	}
 
 	@Activate


### PR DESCRIPTION
As described in [LPS-115139](https://issues.liferay.com/browse/LPS-115139), the call to `Object.entries` [here](https://git.io/Jfy4v) is throwing an error on IE11.

We think it shouldn't because we have a polyfill for this function in the [frontend-compatibility-ie](https://git.io/Jfy4U) module, but it seems that the polyfill is loaded after it is used.

So in this change, we change the location of where those scripts will be loaded.

Previously: https://github.com/wincent/liferay-portal/pull/323