### PR TITLE
[TS] LPS-114933

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/format_xml.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/format_xml.es.js
@@ -67,4 +67,55 @@ describe('Liferay.Util.formatXML', () => {
 
 		expect(formatXML(input, options)).toEqual(expectedOutput);
 	});
+
+	it('throws an error if CDATA blocks in content parameter do not retain their original formatting', () => {
+		const options = {newLine: '\n', tagIndent: '  '};
+
+		const input =
+			' <?xml xlmns:a="http://www.w3.org/TR/html4/" version="1.0" encoding="UTF-8"?>\n' +
+			'<!DOCTYPE note>\n' +
+			'\n' +
+			'<a:note>  					<a:to>Foo</a:to>\n' +
+			'	<a:from>Bar</a:from><a:heading>FooBar</a:heading>\n' +
+			'					<a:body>FooBarBaz!</a:body>\n' +
+			'</a:note>\n' +
+			'<script><![CDATA[<message> FooBarBaz </message> ]]></script>\n' +
+			'<script>\n' +
+			'<![CDATA[\n' +
+			'  <#-- FooBarBaz -->\n' +
+			'  <#if foo && bar>\n' +
+			'    <#assign foo = "bar">\n' +
+			'  </#if>\n' +
+			'  <#if bar>\n' +
+			'        <#if baz><#assign bar = "baz">\n' +
+			'      </#if></#if>\n' +
+			']]>\n' +
+			'          </script>\n';
+
+		const expectedOutput =
+			'<?xml xlmns:a="http://www.w3.org/TR/html4/" version="1.0" encoding="UTF-8"?>\n' +
+			'<!DOCTYPE note>\n' +
+			'<a:note>\n' +
+			'  <a:to>Foo</a:to>\n' +
+			'  <a:from>Bar</a:from>\n' +
+			'  <a:heading>FooBar</a:heading>\n' +
+			'  <a:body>FooBarBaz!</a:body>\n' +
+			'</a:note>\n' +
+			'<script>\n' +
+			'  <![CDATA[<message> FooBarBaz </message> ]]>\n' +
+			'</script>\n' +
+			'<script>\n' +
+			'  <![CDATA[\n' +
+			'    <#-- FooBarBaz -->\n' +
+			'    <#if foo && bar>\n' +
+			'      <#assign foo = "bar">\n' +
+			'    </#if>\n' +
+			'    <#if bar>' +
+			'          <#if baz><#assign bar = "baz">\n' +
+			'        </#if></#if>\n' +
+			'  ]]>\n' +
+			'</script';
+
+		expect(formatXML(input, options)).toEqual(expectedOutput);
+	});
 });

--- a/modules/apps/frontend-js/frontend-js-web/test/liferay/util/format_xml.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/test/liferay/util/format_xml.es.js
@@ -72,25 +72,24 @@ describe('Liferay.Util.formatXML', () => {
 		const options = {newLine: '\n', tagIndent: '  '};
 
 		const input =
-			' <?xml xlmns:a="http://www.w3.org/TR/html4/" version="1.0" encoding="UTF-8"?>\n' +
-			'<!DOCTYPE note>\n' +
-			'\n' +
-			'<a:note>  					<a:to>Foo</a:to>\n' +
-			'	<a:from>Bar</a:from><a:heading>FooBar</a:heading>\n' +
-			'					<a:body>FooBarBaz!</a:body>\n' +
-			'</a:note>\n' +
+			` <?xml xlmns:a="http://www.w3.org/TR/html4/" version="1.0" encoding="UTF-8"?>
+			<!DOCTYPE note>
+			
+			<a:note>  					<a:to>Foo</a:to>
+				<a:from>Bar</a:from><a:heading>FooBar</a:heading>
+								<a:body>FooBarBaz!</a:body>
+			</a:note>\n` +
 			'<script><![CDATA[<message> FooBarBaz </message> ]]></script>\n' +
-			'<script>\n' +
-			'<![CDATA[\n' +
-			'  <#-- FooBarBaz -->\n' +
-			'  <#if foo && bar>\n' +
-			'    <#assign foo = "bar">\n' +
-			'  </#if>\n' +
-			'  <#if bar>\n' +
-			'        <#if baz><#assign bar = "baz">\n' +
-			'      </#if></#if>\n' +
-			']]>\n' +
-			'          </script>\n';
+			'<script><![CDATA[\n' +
+			'    <#-- FooBarBaz -->\n' +
+			'    <#if foo && bar>\n' +
+			'      <#assign foo = "bar">\n' +
+			'    </#if>\n' +
+			'    <#if bar>\n' +
+			'            <#if baz><#assign bar = "baz">\n' +
+			'        </#if></#if>\n' +
+			'      ]]>\n' +
+			'        </script>';
 
 		const expectedOutput =
 			'<?xml xlmns:a="http://www.w3.org/TR/html4/" version="1.0" encoding="UTF-8"?>\n' +
@@ -110,11 +109,11 @@ describe('Liferay.Util.formatXML', () => {
 			'    <#if foo && bar>\n' +
 			'      <#assign foo = "bar">\n' +
 			'    </#if>\n' +
-			'    <#if bar>' +
-			'          <#if baz><#assign bar = "baz">\n' +
+			'    <#if bar>\n' +
+			'            <#if baz><#assign bar = "baz">\n' +
 			'        </#if></#if>\n' +
-			'  ]]>\n' +
-			'</script';
+			'      ]]>\n' +
+			'</script>';
 
 		expect(formatXML(input, options)).toEqual(expectedOutput);
 	});


### PR DESCRIPTION
From @jesseyeh-liferay 

**Previous Pull Requests**

https://github.com/ChrisKian/liferay-portal/pull/226 > https://github.com/wincent/liferay-portal/pull/314

**Changelog**

* Integrate feedback from https://github.com/wincent/liferay-portal/pull/314#discussion_r435795320
* Add the `<` and `>` characters to `STR_TOKEN_CDATA` to account for an edge case in which there is unnecessary whitespace between a CDATA block and the enclosing tags of its parent, e.g.,
```
<tag>
    <![CDATA[
    ...
    ]]>
                </tag> // unneccessary whitespace
```
* Add a test to check that XML formatting is not applied to CDATA blocks

> LPS-114933 resolves an issue in which XML formatting is incorrectly applied to CDATA blocks in embedded FreeMarker templates in a workflow definition. Since CDATA is just text data that is intended to be interpreted literally, this solution opts to apply no additional formatting, and instead, preserves however the CDATA was originally represented.
>
> To accomplish this:
> 1. REGEX_CDATA is used to identify all CDATA blocks in content
> 1. The identified CDATA blocks in content are temporarily replaced by STR_TOKEN_CDATA
> 1. The original implementation does additional pre-processing on content
> 1. All STR_TOKEN_CDATA instances in content are replaced by the CDATA blocks from Step 1
> 1. A REGEX_CDATA conditional is inserted before the REGEX_DECLARATIVE_OPEN conditional so as to prevent CDATA blocks from incorrectly branching into the latter