### PR TITLE
LPS-113561 Avoid use of Liferay.provide in message-boards-web

### DIFF
--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message.jsp
@@ -63,83 +63,80 @@ MBBreadcrumbUtil.addPortletBreadcrumbEntries(message, request, renderResponse);
 </div>
 
 <aui:script require="metal-dom/src/all/dom as domAll">
-	Liferay.provide(window, '<portlet:namespace />addReplyToMessage', function (
-		messageId,
-		quote
-	) {
-		var addQuickReplyContainer = document.querySelector(
-			'#<portlet:namespace />addReplyToMessage' + messageId + ' .panel'
+window['<portlet:namespace />addReplyToMessage'] = function (messageId, quote) {
+	var addQuickReplyContainer = document.querySelector(
+		'#<portlet:namespace />addReplyToMessage' + messageId + ' .panel'
+	);
+
+	if (addQuickReplyContainer) {
+		<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/message_boards/get_edit_message_quick" var="editMessageQuickURL">
+			<portlet:param name="redirect" value="<%= currentURL %>" />
+		</liferay-portlet:resourceURL>
+
+		var editMessageQuickURL = Liferay.Util.addParams(
+			'<portlet:namespace />messageId=' + messageId,
+			'<%= editMessageQuickURL.toString() %>'
 		);
 
-		if (addQuickReplyContainer) {
-			<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="/message_boards/get_edit_message_quick" var="editMessageQuickURL">
-				<portlet:param name="redirect" value="<%= currentURL %>" />
-			</liferay-portlet:resourceURL>
-
-			var editMessageQuickURL = Liferay.Util.addParams(
-				'<portlet:namespace />messageId=' + messageId,
-				'<%= editMessageQuickURL.toString() %>'
+		if (quote) {
+			editMessageQuickURL = Liferay.Util.addParams(
+				'<portlet:namespace />quote=true',
+				editMessageQuickURL
 			);
-
-			if (quote) {
-				editMessageQuickURL = Liferay.Util.addParams(
-					'<portlet:namespace />quote=true',
-					editMessageQuickURL
-				);
-			}
-
-			var addQuickReplyLoadingMask = document.querySelector(
-				'#<portlet:namespace />addReplyToMessage' +
-					messageId +
-					' .loading-animation'
-			);
-
-			addQuickReplyContainer.classList.add('hide');
-			addQuickReplyLoadingMask.classList.remove('hide');
-
-			Liferay.Util.fetch(editMessageQuickURL)
-				.then(function (response) {
-					return response.text();
-				})
-				.then(function (response) {
-					var editorName =
-						'<portlet:namespace />replyMessageBody' + messageId;
-
-					if (window[editorName]) {
-						window[editorName].dispose();
-						Liferay.destroyComponent(editorName);
-					}
-
-					addQuickReplyContainer.innerHTML = response;
-
-					domAll.globalEval.runScriptsInElement(addQuickReplyContainer);
-
-					addQuickReplyContainer.classList.remove('hide');
-					addQuickReplyLoadingMask.classList.add('hide');
-
-					var parentMessageIdInput = addQuickReplyContainer.querySelector(
-						'#<portlet:namespace />parentMessageId'
-					);
-
-					if (parentMessageIdInput) {
-						parentMessageIdInput.value = messageId;
-					}
-
-					Liferay.componentReady(editorName).then(function (editor) {
-						editor.focus();
-					});
-
-					if (addQuickReplyContainer && AUI().UA.mobile) {
-						addQuickReplyContainer.scrollIntoView(true);
-					}
-
-					Liferay.Util.toggleDisabled(
-						'#<portlet:namespace />replyMessageButton' + messageId,
-						true
-					);
-				});
 		}
-	});
+
+		var addQuickReplyLoadingMask = document.querySelector(
+			'#<portlet:namespace />addReplyToMessage' +
+				messageId +
+				' .loading-animation'
+		);
+
+		addQuickReplyContainer.classList.add('hide');
+		addQuickReplyLoadingMask.classList.remove('hide');
+
+		Liferay.Util.fetch(editMessageQuickURL)
+			.then(function (response) {
+				return response.text();
+			})
+			.then(function (response) {
+				var editorName =
+					'<portlet:namespace />replyMessageBody' + messageId;
+
+				if (window[editorName]) {
+					window[editorName].dispose();
+					Liferay.destroyComponent(editorName);
+				}
+
+				addQuickReplyContainer.innerHTML = response;
+
+				domAll.globalEval.runScriptsInElement(addQuickReplyContainer);
+
+				addQuickReplyContainer.classList.remove('hide');
+				addQuickReplyLoadingMask.classList.add('hide');
+
+				var parentMessageIdInput = addQuickReplyContainer.querySelector(
+					'#<portlet:namespace />parentMessageId'
+				);
+
+				if (parentMessageIdInput) {
+					parentMessageIdInput.value = messageId;
+				}
+
+				Liferay.componentReady(editorName).then(function (editor) {
+					editor.focus();
+				});
+
+				if (addQuickReplyContainer && AUI().UA.mobile) {
+					addQuickReplyContainer.scrollIntoView(true);
+				}
+
+				Liferay.Util.toggleDisabled(
+					'#<portlet:namespace />replyMessageButton' + messageId,
+					true
+				);
+			});
+	}
+};
 </aui:script>
 
 <aui:script>


### PR DESCRIPTION
As part of [LPS-113561](https://issues.liferay.com/browse/LPS-113561) we
eventually want to deprecate the `Liferay.provide` function.

To test this change:

- Navigate to "Content and Data > Message Boards"
- Click on the "+" button and choose "Thread"
- Enter a subject for the thread
- Add some text to the "Content" field
- Scroll down and click on the "Publish" button
- Click on the "Reply" button
- Type some text in the "Body" field
- Click on the publish button

Additionally you can also

- Navigate to "Site Builder > Pages"
- Click on the "+" button to create a new page
- Select the "Blank" template from basic templates
- Type a new for your page
- Click on the "Add" button
- Drag and drop the "Message Boards" widget on your page
- Click on the "Publish" button
- From the sidebar on the left click on "Go to Site"
- Click on your page's tab
- Click on the "New Thread" button
- Add a title and some content for your thread
- Click on the "Publish" button
- Click on the "Reply" button
- Type some text in the "Body" field
- Click on the publish button

As a result the replies to the thread you created should be visible and
no JS errors should appear in the browser's console.