### PR TITLE
LPS-113561 Avoid use of Liferay.provide in portal-settings-authentication-opensso-web

### DIFF
--- a/modules/apps/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal.settings.web/opensso.jsp
+++ b/modules/apps/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal.settings.web/opensso.jsp
@@ -103,12 +103,8 @@ window['<portlet:namespace />testOpenSSOSettings'] = function () {
 			return response.text();
 		})
 		.then(function (text) {
-			var parser = new DOMParser();
-
-			var doc = parser.parseFromString(text, 'text/html');
-
 			Liferay.Util.openModal({
-				bodyHTML: doc.body.innerHTML,
+				bodyHTML: text,
 				size: 'full-screen',
 				title: '<%= UnicodeLanguageUtil.get(request, "opensso") %>',
 			});

--- a/modules/apps/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal.settings.web/opensso.jsp
+++ b/modules/apps/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal.settings.web/opensso.jsp
@@ -56,12 +56,9 @@ String version = openSSOConfiguration.version();
 	<%@ include file="/dynamic_include/com.liferay.portal.settings.web/opensso_user_name.jspf" %>
 </aui:fieldset>
 
-<aui:script use="aui-io-plugin-deprecated,liferay-util-window">
+<aui:script>
 window['<portlet:namespace />testOpenSSOSettings'] = function () {
-	var A = AUI();
-
 	var data = {};
-
 	data.<portlet:namespace />openSsoLoginURL =
 		document.<portlet:namespace />fm[
 			'<portlet:namespace /><%= PortalSettingsOpenSSOConstants.FORM_PARAMETER_NAMESPACE %>loginURL'
@@ -91,19 +88,39 @@ window['<portlet:namespace />testOpenSSOSettings'] = function () {
 			'<portlet:namespace /><%= PortalSettingsOpenSSOConstants.FORM_PARAMETER_NAMESPACE %>lastNameAttr'
 		].value;
 
-	var url =
+	var baseUrl =
 		'<portlet:renderURL windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>"><portlet:param name="mvcRenderCommandName" value="/portal_settings/test_opensso" /></portlet:renderURL>';
 
-	var dialog = Liferay.Util.Window.getWindow({
-		dialog: {
-			destroyOnHide: true,
-		},
-		title: '<%= UnicodeLanguageUtil.get(request, "opensso") %>',
+	var url = new URL(baseUrl);
+
+	var searchParams = Liferay.Util.objectToFormData(data);
+	searchParams.forEach(function (value, key) {
+		url.searchParams.append(key, value);
 	});
 
-	dialog.plug(A.Plugin.IO, {
-		data: data,
-		uri: url,
-	});
+	Liferay.Util.fetch(url)
+		.then(function (response) {
+			return response.text();
+		})
+		.then(function (text) {
+			var parser = new DOMParser();
+
+			var doc = parser.parseFromString(text, 'text/html');
+
+			Liferay.Util.openModal({
+				bodyHTML: doc.body.innerHTML,
+				size: 'full-screen',
+				title: '<%= UnicodeLanguageUtil.get(request, "opensso") %>',
+			});
+		})
+		.catch(function (error) {
+			Liferay.Util.openToast({
+				message: Liferay.Language.get(
+					'an-unexpected-system-error-occurred'
+				),
+				title: Liferay.Language.get('error'),
+				type: 'danger',
+			});
+		});
 };
 </aui:script>

--- a/modules/apps/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal.settings.web/opensso.jsp
+++ b/modules/apps/portal-settings/portal-settings-authentication-opensso-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal.settings.web/opensso.jsp
@@ -56,59 +56,54 @@ String version = openSSOConfiguration.version();
 	<%@ include file="/dynamic_include/com.liferay.portal.settings.web/opensso_user_name.jspf" %>
 </aui:fieldset>
 
-<aui:script>
-	Liferay.provide(
-		window,
-		'<portlet:namespace />testOpenSSOSettings',
-		function () {
-			var A = AUI();
+<aui:script use="aui-io-plugin-deprecated,liferay-util-window">
+window['<portlet:namespace />testOpenSSOSettings'] = function () {
+	var A = AUI();
 
-			var data = {};
+	var data = {};
 
-			data.<portlet:namespace />openSsoLoginURL =
-				document.<portlet:namespace />fm[
-					'<portlet:namespace /><%= PortalSettingsOpenSSOConstants.FORM_PARAMETER_NAMESPACE %>loginURL'
-				].value;
-			data.<portlet:namespace />openSsoLogoutURL =
-				document.<portlet:namespace />fm[
-					'<portlet:namespace /><%= PortalSettingsOpenSSOConstants.FORM_PARAMETER_NAMESPACE %>logoutURL'
-				].value;
-			data.<portlet:namespace />openSsoServiceURL =
-				document.<portlet:namespace />fm[
-					'<portlet:namespace /><%= PortalSettingsOpenSSOConstants.FORM_PARAMETER_NAMESPACE %>serviceURL'
-				].value;
-			data.<portlet:namespace />openSsoScreenNameAttr =
-				document.<portlet:namespace />fm[
-					'<portlet:namespace /><%= PortalSettingsOpenSSOConstants.FORM_PARAMETER_NAMESPACE %>screenNameAttr'
-				].value;
-			data.<portlet:namespace />openSsoEmailAddressAttr =
-				document.<portlet:namespace />fm[
-					'<portlet:namespace /><%= PortalSettingsOpenSSOConstants.FORM_PARAMETER_NAMESPACE %>emailAddressAttr'
-				].value;
-			data.<portlet:namespace />openSsoFirstNameAttr =
-				document.<portlet:namespace />fm[
-					'<portlet:namespace /><%= PortalSettingsOpenSSOConstants.FORM_PARAMETER_NAMESPACE %>firstNameAttr'
-				].value;
-			data.<portlet:namespace />openSsoLastNameAttr =
-				document.<portlet:namespace />fm[
-					'<portlet:namespace /><%= PortalSettingsOpenSSOConstants.FORM_PARAMETER_NAMESPACE %>lastNameAttr'
-				].value;
+	data.<portlet:namespace />openSsoLoginURL =
+		document.<portlet:namespace />fm[
+			'<portlet:namespace /><%= PortalSettingsOpenSSOConstants.FORM_PARAMETER_NAMESPACE %>loginURL'
+		].value;
+	data.<portlet:namespace />openSsoLogoutURL =
+		document.<portlet:namespace />fm[
+			'<portlet:namespace /><%= PortalSettingsOpenSSOConstants.FORM_PARAMETER_NAMESPACE %>logoutURL'
+		].value;
+	data.<portlet:namespace />openSsoServiceURL =
+		document.<portlet:namespace />fm[
+			'<portlet:namespace /><%= PortalSettingsOpenSSOConstants.FORM_PARAMETER_NAMESPACE %>serviceURL'
+		].value;
+	data.<portlet:namespace />openSsoScreenNameAttr =
+		document.<portlet:namespace />fm[
+			'<portlet:namespace /><%= PortalSettingsOpenSSOConstants.FORM_PARAMETER_NAMESPACE %>screenNameAttr'
+		].value;
+	data.<portlet:namespace />openSsoEmailAddressAttr =
+		document.<portlet:namespace />fm[
+			'<portlet:namespace /><%= PortalSettingsOpenSSOConstants.FORM_PARAMETER_NAMESPACE %>emailAddressAttr'
+		].value;
+	data.<portlet:namespace />openSsoFirstNameAttr =
+		document.<portlet:namespace />fm[
+			'<portlet:namespace /><%= PortalSettingsOpenSSOConstants.FORM_PARAMETER_NAMESPACE %>firstNameAttr'
+		].value;
+	data.<portlet:namespace />openSsoLastNameAttr =
+		document.<portlet:namespace />fm[
+			'<portlet:namespace /><%= PortalSettingsOpenSSOConstants.FORM_PARAMETER_NAMESPACE %>lastNameAttr'
+		].value;
 
-			var url =
-				'<portlet:renderURL windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>"><portlet:param name="mvcRenderCommandName" value="/portal_settings/test_opensso" /></portlet:renderURL>';
+	var url =
+		'<portlet:renderURL windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>"><portlet:param name="mvcRenderCommandName" value="/portal_settings/test_opensso" /></portlet:renderURL>';
 
-			var dialog = Liferay.Util.Window.getWindow({
-				dialog: {
-					destroyOnHide: true,
-				},
-				title: '<%= UnicodeLanguageUtil.get(request, "opensso") %>',
-			});
-
-			dialog.plug(A.Plugin.IO, {
-				data: data,
-				uri: url,
-			});
+	var dialog = Liferay.Util.Window.getWindow({
+		dialog: {
+			destroyOnHide: true,
 		},
-		['aui-io-plugin-deprecated', 'liferay-util-window']
-	);
+		title: '<%= UnicodeLanguageUtil.get(request, "opensso") %>',
+	});
+
+	dialog.plug(A.Plugin.IO, {
+		data: data,
+		uri: url,
+	});
+};
 </aui:script>


### PR DESCRIPTION
As part of [LPS-113561](https://issues.liferay.com/browse/LPS-113561) we eventually want to deprecate the `Liferay.provide` function.

To test this change:

- From the "Global Menu" click on the "Control Panel" tab
- Click on "Configuration > Instance Settings"
- Scroll down to the "Security" section and click on "SSO"
- Click on the "OpenSSO" tab
- Click on On the top right kebabmenu next to "OpenSSO"
- Click on "Test OpenSSO configuration"

As a result, a modal window should be opened and depending of your settings it should either tell you that the connection to the OpenSSO server was successful or that it failed, and there should be no JS errors in the browser's console