### PR TITLE
LPS-113561 Avoid use of Liferay.provide in portal-settings-authentication-cas-web

### DIFF
--- a/modules/apps/portal-settings/portal-settings-authentication-cas-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal.settings.web/cas.jsp
+++ b/modules/apps/portal-settings/portal-settings-authentication-cas-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal.settings.web/cas.jsp
@@ -94,12 +94,8 @@ String noSuchUserRedirectURL = casConfiguration.noSuchUserRedirectURL();
 				return response.text();
 			})
 			.then(function (text) {
-				var parser = new DOMParser();
-
-				var doc = parser.parseFromString(text, 'text/html');
-
 				Liferay.Util.openModal({
-					bodyHTML: doc.body.innerHTML,
+					bodyHTML: text,
 					size: 'full-screen',
 					title: '<%= UnicodeLanguageUtil.get(request, "cas") %>',
 				});

--- a/modules/apps/portal-settings/portal-settings-authentication-cas-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal.settings.web/cas.jsp
+++ b/modules/apps/portal-settings/portal-settings-authentication-cas-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal.settings.web/cas.jsp
@@ -57,47 +57,42 @@ String noSuchUserRedirectURL = casConfiguration.noSuchUserRedirectURL();
 	<aui:input cssClass="lfr-input-text-container" helpMessage="cas-no-such-user-redirect-url-help" label="no-such-user-redirect-url" name='<%= PortalSettingsCASConstants.FORM_PARAMETER_NAMESPACE + "noSuchUserRedirectURL" %>' type="text" value="<%= noSuchUserRedirectURL %>" />
 </aui:fieldset>
 
-<aui:script>
-	Liferay.provide(
-		window,
-		'<portlet:namespace />testCasSettings',
-		function () {
-			var A = AUI();
+<aui:script use="aui-io-plugin-deprecated,liferay-util-window">
+	window['<portlet:namespace />testCasSettings'] = function () {
+		var A = AUI();
 
-			var data = {};
+		var data = {};
 
-			data.<portlet:namespace />casLoginURL =
-				document.<portlet:namespace />fm[
-					'<portlet:namespace /><%= PortalSettingsCASConstants.FORM_PARAMETER_NAMESPACE %>loginURL'
-				].value;
-			data.<portlet:namespace />casLogoutURL =
-				document.<portlet:namespace />fm[
-					'<portlet:namespace /><%= PortalSettingsCASConstants.FORM_PARAMETER_NAMESPACE %>logoutURL'
-				].value;
-			data.<portlet:namespace />casServerURL =
-				document.<portlet:namespace />fm[
-					'<portlet:namespace /><%= PortalSettingsCASConstants.FORM_PARAMETER_NAMESPACE %>serverURL'
-				].value;
-			data.<portlet:namespace />casServiceURL =
-				document.<portlet:namespace />fm[
-					'<portlet:namespace /><%= PortalSettingsCASConstants.FORM_PARAMETER_NAMESPACE %>serviceURL'
-				].value;
+		data.<portlet:namespace />casLoginURL =
+			document.<portlet:namespace />fm[
+				'<portlet:namespace /><%= PortalSettingsCASConstants.FORM_PARAMETER_NAMESPACE %>loginURL'
+			].value;
+		data.<portlet:namespace />casLogoutURL =
+			document.<portlet:namespace />fm[
+				'<portlet:namespace /><%= PortalSettingsCASConstants.FORM_PARAMETER_NAMESPACE %>logoutURL'
+			].value;
+		data.<portlet:namespace />casServerURL =
+			document.<portlet:namespace />fm[
+				'<portlet:namespace /><%= PortalSettingsCASConstants.FORM_PARAMETER_NAMESPACE %>serverURL'
+			].value;
+		data.<portlet:namespace />casServiceURL =
+			document.<portlet:namespace />fm[
+				'<portlet:namespace /><%= PortalSettingsCASConstants.FORM_PARAMETER_NAMESPACE %>serviceURL'
+			].value;
 
-			var url =
-				'<portlet:renderURL windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>"><portlet:param name="mvcRenderCommandName" value="/portal_settings/test_cas" /></portlet:renderURL>';
+		var url =
+			'<portlet:renderURL windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>"><portlet:param name="mvcRenderCommandName" value="/portal_settings/test_cas" /></portlet:renderURL>';
 
-			var dialog = Liferay.Util.Window.getWindow({
-				dialog: {
-					destroyOnHide: true,
-				},
-				title: '<%= UnicodeLanguageUtil.get(request, "cas") %>',
-			});
+		var dialog = Liferay.Util.Window.getWindow({
+			dialog: {
+				destroyOnHide: true,
+			},
+			title: '<%= UnicodeLanguageUtil.get(request, "cas") %>',
+		});
 
-			dialog.plug(A.Plugin.IO, {
-				data: data,
-				uri: url,
-			});
-		},
-		['aui-io-plugin-deprecated', 'liferay-util-window']
-	);
+		dialog.plug(A.Plugin.IO, {
+			data: data,
+			uri: url,
+		});
+	};
 </aui:script>


### PR DESCRIPTION
As part of [LPS-113561](https://issues.liferay.com/browse/LPS-113561) we eventually want to deprecate the `Liferay.provide` function

To test this change:

- From the "Global Menu" select the "Control Panel" tab
- Click on "Configuration > Instance Settings"
- In the "Security" section click on "SSO"
- Click on the kebab menu to the right of "CAS Server" and click on "Test CAS Configuration"

As a result a modal window should appear and depending on the values you entered for your CAS server it should either notify you that the connection was successful or that it failed and no JS errors should appear in your browser's console