### PR TITLE
LPS-115254 Closing the session timeout warning immediately causes it to reappear

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -233,7 +233,6 @@ AUI.add(
 					var instance = this;
 
 					var sessionLength = instance.get('sessionLength');
-					var sessionState = instance.get('sessionState');
 					var warningTime = instance.get('warningTime');
 
 					var registered = instance._registered;
@@ -241,6 +240,8 @@ AUI.add(
 					var interval = 1000;
 
 					instance._intervalId = A.setInterval(() => {
+						var sessionState = instance.get('sessionState');
+
 						var timeOffset;
 
 						var timestamp = instance.get('timestamp');


### PR DESCRIPTION
Hello @wincent,

I'm sending this through you since it seems you were the last reviewer of this file. Please let me know if it would be better for someone else to review though.

The issue is that the `sessionState` variable is only fetching one time before starting the interval function. Inside of the interval there is a call to `instance.warn()` if the `sessionState` is not `warned`. When the instance is warned the `sessionState` is then set to `warned`.

Since the variable is not reset however we will constantly trigger the warning and set `warningMoment` to `true`. This value is used in `_beforeHostWarned` for its interval function. Whenever `warningMoment` is `true` we call `banner.show()` which then displays the pop up window again.

By moving the declaration inside of the interval, `warningMoment` will be set appropriately and the popup window will remain closed if closed by the user.

Please let me know if you have any questions or concerns.

Thank you.