### PR TITLE
LPS-115202 Site Selector icon becomes difficult to see when hovering over it in the 7.0 theme

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/resources/META-INF/resources/product_navigation_product_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-product-menu-theme-contributor/src/main/resources/META-INF/resources/product_navigation_product_menu.scss
@@ -410,6 +410,10 @@
 	.icon-sites {
 		a {
 			color: $product-menu-panel-title-color;
+
+			&:hover {
+				color: $product-menu-panel-title-color;
+			}
 		}
 
 		position: absolute;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-115202

From @wanderlast: 

> This fixes an issue that specifically is only visible in the DXP 7.0 theme, but not in the current theme in Master where the site item selector icon can become difficult to see/invisible when hovering over it. This is caused by the CSS using the default .product-menu > a > &:hover color since icon-sites only specifies a color for a link, not hovering over a link. We fix this by explicitly setting a color while hovering over it.