### PR TITLE
LPS-115204 Adds React Hydration to Clay tags

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/build.gradle
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:frontend-js:frontend-js-loader-modules-extender-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-soy")
+	compileOnly project(":apps:portal-template:portal-template-react-renderer-api")
 	compileOnly project(":apps:portal-template:portal-template-soy-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/package.json
@@ -39,6 +39,7 @@
 		"@clayui/time-picker": "3.1.3",
 		"@clayui/tooltip": "3.3.0",
 		"@clayui/upper-toolbar": "3.1.0",
+		"classnames": "2.2.6",
 		"clay-alert": "2.21.3",
 		"clay-autocomplete": "2.21.3",
 		"clay-badge": "2.21.3",

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/util/ReactRendererProvider.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/internal/util/ReactRendererProvider.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.frontend.taglib.clay.internal.util;
+
+import com.liferay.portal.template.react.renderer.ReactRenderer;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Chema Balsas
+ */
+@Component(service = {})
+public class ReactRendererProvider {
+
+	public static ReactRenderer getReactRenderer() {
+		return _reactRenderer;
+	}
+
+	@Reference(unbind = "-")
+	public void setReactRenderer(ReactRenderer reactRenderer) {
+		_reactRenderer = reactRenderer;
+	}
+
+	private static ReactRenderer _reactRenderer;
+
+}

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/NavigationBarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/NavigationBarTag.java
@@ -19,6 +19,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.servlet.jsp.JspException;
@@ -80,6 +81,11 @@ public class NavigationBarTag extends BaseContainerTag {
 	}
 
 	@Override
+	protected String getHydratedModuleName() {
+		return "frontend-taglib-clay/NavigationBar";
+	}
+
+	@Override
 	protected String processCssClasses(Set<String> cssClasses) {
 		cssClasses.add("navbar");
 		cssClasses.add("navbar-collapse-absolute");
@@ -91,6 +97,14 @@ public class NavigationBarTag extends BaseContainerTag {
 			_inverted ? "navigation-bar-secondary" : "navigation-bar-light");
 
 		return super.processCssClasses(cssClasses);
+	}
+
+	@Override
+	protected Map<String, Object> processData(Map<String, Object> data) {
+		data.put("inverted", _inverted);
+		data.put("navigationItems", _navigationItems);
+
+		return super.processData(data);
 	}
 
 	@Override

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/NavigationBar.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/NavigationBar.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayLayout from '@clayui/layout';
+import ClayLink from '@clayui/link';
+import ClayNavigationBar from '@clayui/navigation-bar';
+import classNames from 'classnames';
+import React from 'react';
+
+export default function NavigationBar({cssClass, inverted, navigationItems}) {
+	return (
+		<ClayLayout.ContainerFluid className={classNames('p-0', cssClass)}>
+			<ClayNavigationBar
+				inverted={inverted}
+				triggerLabel={navigationItems.find(({active}) => active).label}
+			>
+				{navigationItems.map(({active, href, label}) => (
+					<ClayNavigationBar.Item active={active} key={label}>
+						<ClayLink
+							className="nav-link"
+							displayType="unstyled"
+							href={href}
+						>
+							{label}
+						</ClayLink>
+					</ClayNavigationBar.Item>
+				))}
+			</ClayNavigationBar>
+		</ClayLayout.ContainerFluid>
+	);
+}


### PR DESCRIPTION
Initial attempt at bringing React Hydration to our Clay tags. Motivated by this regression: [The dropdown list of the site scope is missing in the define permission](https://issues.liferay.com/browse/LPS-115204)

### Adds Generic React Hydration support to `BaseContainerTag`
React Hydration is pretty simple based on our existing `ReactRenderer`.

In here, we basically defer to the component implementations the following:
- Wether to hydrate or not via `shouldHydrate`. False by default
- Which component to use to hydrate the view. Null by default
- Additional data to be passed down to the component

With that, we call `reactRenderer.renderReact` BEFORE closing the main container. This will automatically insert a placeholder div within the component tag boundaries. When hydrating, the component is mounted on the parent element of such placeholder making this work in a clean way without the need for additional identifiers.

### Implements Hydration in clay:navigation-bar

On small screens, <ClayNavigationBar /> collapses into a single trigger element that expands and collapses the navigation items list. Since we neeed JS for that anyways, we always hydrate ClayNavigationBar making the React version re-render on top of the server-side initial markup.

See this working in navigation bars across the product, like `Content & Data > Web Content`. Breakpoint triggers for small screens:

![navbar](https://user-images.githubusercontent.com/905006/84494404-bb4c1f00-aca9-11ea-8872-bb1a78eff3c5.gif)
