### PR TITLE
LPS-115074 Update modal usages in account modules

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/add_domains.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/add_domains.jsp
@@ -73,18 +73,12 @@ String eventName = ParamUtil.getString(request, "eventName", liferayPortletRespo
 			}
 		}
 
-		<portlet:namespace/>closePopup();
-	}
-
-	function <portlet:namespace/>closePopup() {
-		var Util = Liferay.Util;
-
-		var openingLiferay = Util.getOpener().Liferay;
+		var openingLiferay = Liferay.Util.getOpener().Liferay;
 
 		openingLiferay.fire('<%= HtmlUtil.escapeJS(eventName) %>', {
 			data: document.getElementById('<portlet:namespace />domain').value,
 		});
 
-		Util.getWindow().hide();
+		openingLiferay.fire('closeModal');
 	}
 </aui:script>

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/domains.jsp
@@ -134,58 +134,51 @@ List<String> domains = accountEntryDisplay.getDomains();
 		addDomainsIcon.addEventListener('click', function (event) {
 			event.preventDefault();
 
-			Liferay.Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						destroyOnHide: true,
-						height: 350,
-						modal: true,
-						width: 800,
+			Liferay.Util.openModal({
+				customEvents: [
+					{
+						name:
+							'<%= liferayPortletResponse.getNamespace() + "addDomains" %>',
+						onEvent: function (event) {
+							var newDomains = event.data.split(',');
+
+							newDomains.forEach(function (domain) {
+								domain = domain.trim();
+
+								if (!domains.includes(domain)) {
+									var rowColumns = [];
+
+									rowColumns.push(Liferay.Util.escape(domain));
+									rowColumns.push(
+										'<a class="modify-link pull-right" data-rowId="' +
+											domain +
+											'" href="javascript:;"><%= UnicodeFormatter.toString(removeDomainIcon) %></a>'
+									);
+
+									searchContainer.addRow(rowColumns, domain);
+
+									domains.push(domain);
+								}
+							});
+
+							searchContainer.updateDataStore();
+
+							domainsInput.value = domains.join(',');
+						},
 					},
-					dialogIframe: {
-						bodyCssClass: 'dialog-with-footer',
-					},
-					id:
-						'<%= liferayPortletResponse.getNamespace() + "addDomains" %>',
-					title: '<liferay-ui:message key="add-domain" />',
+				],
+				id: '<%= liferayPortletResponse.getNamespace() + "addDomains" %>',
+				title: '<liferay-ui:message key="add-domain" />',
 
-					<%
-					PortletURL addDomainsURL = renderResponse.createRenderURL();
+				<%
+				PortletURL addDomainsURL = renderResponse.createRenderURL();
 
-					addDomainsURL.setParameter("mvcPath", "/account_entries_admin/account_entry/add_domains.jsp");
-					addDomainsURL.setWindowState(LiferayWindowState.POP_UP);
-					%>
+				addDomainsURL.setParameter("mvcPath", "/account_entries_admin/account_entry/add_domains.jsp");
+				addDomainsURL.setWindowState(LiferayWindowState.POP_UP);
+				%>
 
-					uri: '<%= addDomainsURL.toString() %>',
-				},
-				function (event) {
-					var newDomains = event.data.split(',');
-
-					newDomains.forEach(function (domain) {
-						domain = domain.trim();
-
-						if (!domains.includes(domain)) {
-							var rowColumns = [];
-
-							rowColumns.push(Liferay.Util.escape(domain));
-							rowColumns.push(
-								'<a class="modify-link pull-right" data-rowId="' +
-									domain +
-									'" href="javascript:;"><%= UnicodeFormatter.toString(removeDomainIcon) %></a>'
-							);
-
-							searchContainer.addRow(rowColumns, domain);
-
-							domains.push(domain);
-						}
-					});
-
-					searchContainer.updateDataStore();
-
-					domainsInput.value = domains.join(',');
-				}
-			);
+				url: '<%= addDomainsURL.toString() %>',
+			});
 		});
 	}
 </aui:script>

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/parent_account_entry.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/parent_account_entry.jsp
@@ -137,54 +137,44 @@ if (accountEntryDisplay.getAccountEntryId() > 0) {
 		selectParentAccountEntryIcon.addEventListener('click', function (event) {
 			event.preventDefault();
 
-			Liferay.Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						destroyOnHide: true,
-						modal: true,
-					},
-					dialogIframe: {
-						bodyCssClass: 'dialog-with-footer',
-					},
-					eventName:
-						'<%= liferayPortletResponse.getNamespace() + "selectAccountEntry" %>',
-					id:
-						'<%= liferayPortletResponse.getNamespace() + "selectParentAccountEntry" %>',
-					selectedData: [
-						'<%= (accountEntryDisplay.getAccountEntryId() > 0) ? accountEntryDisplay.getAccountEntryId() : "" %>',
-						parentAccountEntryInput.value,
-					],
-					title: '<liferay-ui:message key="assign-parent-account" />',
-
-					<%
-					PortletURL selectParentAccountEntryURL = renderResponse.createRenderURL();
-
-					selectParentAccountEntryURL.setParameter("mvcPath", "/account_users_admin/select_account_entry.jsp");
-					selectParentAccountEntryURL.setWindowState(LiferayWindowState.POP_UP);
-					%>
-
-					uri: '<%= selectParentAccountEntryURL.toString() %>',
-				},
-				function (event) {
-					parentAccountEntryInput.value = event.accountentryid;
+			Liferay.Util.openModal({
+				id:
+					'<%= liferayPortletResponse.getNamespace() + "selectParentAccountEntry" %>',
+				onSelect: function (selectedItem) {
+					parentAccountEntryInput.value = selectedItem.accountentryid;
 
 					var rowColumns = [];
 
-					rowColumns.push(event.entityname);
+					rowColumns.push(selectedItem.entityname);
 					rowColumns.push(
 						'<a class="modify-link" data-rowId="' +
-							event.entityid +
+							selectedItem.entityid +
 							'" href="javascript:;"><%= UnicodeFormatter.toString(removeParentAccountEntryIcon) %></a>'
 					);
 
 					searchContainer.deleteRow(1, searchContainer.getData());
 
-					searchContainer.addRow(rowColumns, event.entityid);
+					searchContainer.addRow(rowColumns, selectedItem.entityid);
 
-					searchContainer.updateDataStore(event.entityid);
-				}
-			);
+					searchContainer.updateDataStore(selectedItem.entityid);
+				},
+				selectEventName:
+					'<%= liferayPortletResponse.getNamespace() + "selectAccountEntry" %>',
+				selectedData: [
+					'<%= (accountEntryDisplay.getAccountEntryId() > 0) ? accountEntryDisplay.getAccountEntryId() : "" %>',
+					parentAccountEntryInput.value,
+				],
+				title: '<liferay-ui:message key="assign-parent-account" />',
+
+				<%
+				PortletURL selectParentAccountEntryURL = renderResponse.createRenderURL();
+
+				selectParentAccountEntryURL.setParameter("mvcPath", "/account_users_admin/select_account_entry.jsp");
+				selectParentAccountEntryURL.setWindowState(LiferayWindowState.POP_UP);
+				%>
+
+				url: '<%= selectParentAccountEntryURL.toString() %>',
+			});
 		});
 	}
 </aui:script>

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/account_user/account_entries.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/account_user/account_entries.jsp
@@ -199,27 +199,14 @@ portletDisplay.setURLBack(backURL);
 				searchContainerData = searchContainerData.split(',');
 			}
 
-			Util.selectEntity(
-				{
-					dialog: {
-						constrain: true,
-						destroyOnHide: true,
-						modal: true,
-					},
-					eventName: '<portlet:namespace />selectAccountEntry',
-					id: '<portlet:namespace />selectAccountEntry',
-					selectedData: searchContainerData,
-					title:
-						'<liferay-ui:message arguments="account" key="select-x" />',
-					uri:
-						'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/account_users_admin/select_account_entry.jsp" /><portlet:param name="userId" value="<%= String.valueOf(selUser.getUserId()) %>" /></portlet:renderURL>',
-				},
-				function (event) {
-					var entityId = event.entityid;
+			Util.openModal({
+				id: '<portlet:namespace />selectAccountEntry',
+				onSelect: function (selectedItem) {
+					var entityId = selectedItem.entityid;
 
 					var rowColumns = [];
 
-					rowColumns.push(event.entityname);
+					rowColumns.push(selectedItem.entityname);
 					rowColumns.push(<%= StringPool.BLANK %>);
 					rowColumns.push(
 						'<a class="modify-link" data-rowId="' +
@@ -241,8 +228,13 @@ portletDisplay.setURLBack(backURL);
 					document.<portlet:namespace />fm.<portlet:namespace />deleteAccountEntryIds.value = deleteAccountEntryIds.join(
 						','
 					);
-				}
-			);
+				},
+				selectEventName: '<portlet:namespace />selectAccountEntry',
+				selectedData: searchContainerData,
+				title: '<liferay-ui:message arguments="account" key="select-x" />',
+				url:
+					'<portlet:renderURL windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcPath" value="/account_users_admin/select_account_entry.jsp" /><portlet:param name="userId" value="<%= String.valueOf(selUser.getUserId()) %>" /></portlet:renderURL>',
+			});
 		});
 	}
 </aui:script>

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/js/ManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/js/ManagementToolbarDefaultEventHandler.es.js
@@ -12,7 +12,13 @@
  * details.
  */
 
-import {DefaultEventHandler, ItemSelectorDialog} from 'frontend-js-web';
+import {
+	DefaultEventHandler,
+	ItemSelectorDialog,
+	createPortletURL,
+	navigate,
+	openModal,
+} from 'frontend-js-web';
 
 class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	activateAccountUsers(itemData) {
@@ -64,28 +70,22 @@ class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	}
 
 	addAccountUser(itemData) {
-		Liferay.Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					modal: true,
-				},
-				eventName: this.ns('selectAccountEntry'),
-				id: this.ns('addAccountUser'),
-				title: Liferay.Language.get(itemData.dialogTitle),
-				uri: itemData.accountEntrySelectorURL,
-			},
-			(event) => {
-				var addAccountUserURL = Liferay.Util.PortletURL.createPortletURL(
+		openModal({
+			id: this.ns('addAccountUser'),
+			onSelect: (selectedItem) => {
+				var addAccountUserURL = createPortletURL(
 					itemData.addAccountUserURL,
 					{
-						accountEntryId: event.accountentryid,
+						accountEntryId: selectedItem.accountentryid,
 					}
 				);
 
-				window.location.href = addAccountUserURL;
-			}
-		);
+				navigate(addAccountUserURL);
+			},
+			selectEventName: this.ns('selectAccountEntry'),
+			title: Liferay.Language.get(itemData.dialogTitle),
+			url: itemData.accountEntrySelectorURL,
+		});
 	}
 
 	_openAccountEntrySelector(

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -103,6 +103,7 @@ const openPortletWindow = ({bodyCssClass, portlet, uri, ...otherProps}) => {
 const Modal = ({
 	bodyHTML,
 	buttons,
+	customEvents = [],
 	headerHTML,
 	id,
 	iframeBodyCssClass,
@@ -237,6 +238,16 @@ const Modal = ({
 			eventHandlers.push(selectEventHandler);
 		}
 
+		customEvents.forEach((customEvent) => {
+			if (customEvent.name && customEvent.onEvent) {
+				const eventHandler = Liferay.on(customEvent.name, (event) => {
+					customEvent.onEvent(event);
+				});
+
+				eventHandlers.push(eventHandler);
+			}
+		});
+
 		const closeEventHandler = Liferay.on('closeModal', (event) => {
 			if (event.id && id && event.id !== id) {
 				return;
@@ -259,6 +270,7 @@ const Modal = ({
 			eventHandlers.splice(0, eventHandlers.length);
 		};
 	}, [
+		customEvents,
 		eventHandlersRef,
 		id,
 		onClose,
@@ -459,6 +471,12 @@ Modal.propTypes = {
 			label: PropTypes.string,
 			onClick: PropTypes.func,
 			type: PropTypes.oneOf(['cancel', 'submit']),
+		})
+	),
+	customEvents: PropTypes.arrayOf(
+		PropTypes.shape({
+			name: PropTypes.string,
+			onEvent: PropTypes.func,
 		})
 	),
 	headerHTML: PropTypes.string,


### PR DESCRIPTION
Hey @wincent ,

In this PR we are updating modals in account modules, extending `openModal` API where needed.

Notes:
- 3 out of 4 usages are straightforward. A bit problematic is the 'add domain' modal. Before this PR we used `selectEntity` util, even though there is no selection in the modal. There is an input field and, on click on save button, opener updates. It didn't feel right to just update it to `onSelect`, instead I extended API to support an array of custom events. The select event could fall under it, but it is such a common use case that it still makes sense to have `onSelect` and `selectEventName`.

Test Plan:
1. Global Menu > Control Panel > Accounts > (+) > Create two accounts
1. Account item options > Edit
1. Parent Account section > Select
---
1. Account item options > Edit 
1. Valid Domains section > Add
---
1. Global Menu > Control Panel > Accounts Users > (+)
---
1. Global Menu > Control Panel > Accounts Users > User options > Edit
1. General tab > Accounts tab > Select an account


Please review the code.

Thank you!

/cc @jbalsas 